### PR TITLE
fix(doc-int): adjust doc-int endpoints and endpoints-definitions secret format

### DIFF
--- a/modules/azure-document-intelligence/main.tf
+++ b/modules/azure-document-intelligence/main.tf
@@ -17,13 +17,14 @@ resource "azurerm_cognitive_account" "aca" {
 }
 
 locals {
-  azure_document_intelligence_endpoints = {
-    for key, value in var.accounts : key => azurerm_cognitive_account.aca[key].endpoint
-  }
-  azure_document_intelligence_endpoint_definitions = {
-    for key, value in var.accounts : key => {
+  azure_document_intelligence_endpoints = [
+    for key, value in var.accounts : azurerm_cognitive_account.aca[key].endpoint
+  ]
+  azure_document_intelligence_endpoint_definitions = [
+    for key, value in var.accounts : {
+      name     = key
       endpoint = azurerm_cognitive_account.aca[key].endpoint
       location = azurerm_cognitive_account.aca[key].location
     }
-  }
+  ]
 }

--- a/modules/azure-document-intelligence/module.yaml
+++ b/modules/azure-document-intelligence/module.yaml
@@ -2,7 +2,7 @@
 name: azure-document-intelligence
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-document-intelligence
-version: 2.0.0-rc.1
+version: 2.0.0-rc.2
 changes:
-  - kind: added
-    description: "All Unique Azure Modules start off in the major version `2.0.0` as Unique already supported a lot of modules prior to the public repository which are summarized as `1.x`. Like that, it is easier to separate the modules that were already handed out from the modules that are new and will be handed out in the future."
+  - kind: fixed
+    description: "Wrong format for azure_document_intelligence_endpoints and azure_document_intelligence_endpoint_definitions secrets"


### PR DESCRIPTION
## Describe your changes

This PR fixes the format of the secrets `azure_document_intelligence_endpoints` and `azure_document_intelligence_endpoint_definitions` that were wrongly formatted as map but need to be a list.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
