### PR TITLE
fix(aoai): azure-openai-endpoint-definitions missing key property set to WORKLOAD_IDENTITY

### DIFF
--- a/modules/azure-openai/main.tf
+++ b/modules/azure-openai/main.tf
@@ -3,6 +3,7 @@ locals {
     for account in azurerm_cognitive_account.aca : {
       "endpoint" : account.endpoint,
       "location" : account.location,
+      "key" : "WORKLOAD_IDENTITY",
       "models" : [
         for deployment in azurerm_cognitive_deployment.deployments : {
           "modelName" : deployment.model[0].name,

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -2,7 +2,7 @@
 name: azure-openai
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-openai
-version: 2.0.0-rc.2
+version: 2.0.0-rc.3
 changes:
   - kind: fixed
-    description: "Secrets stored in the wrong format in KeyVault"
+    description: "azure-openai-endpoint-definitions secret was missing key property set to WORKLOAD_IDENTITY"


### PR DESCRIPTION
## Describe your changes

This PR is adding the `key` property with a value of `WORKLOAD_IDENTITY` to the `azure-openai-endpoint-definitions` secret used by node-chat.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
