### PR TITLE
feat(appgw): add AppGW global settings for req and res buffering

### DIFF
--- a/modules/azure-application-gateway/README.md
+++ b/modules/azure-application-gateway/README.md
@@ -61,8 +61,10 @@ No modules.
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for naming resources | `string` | n/a | yes |
 | <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | Private IP address for the frontend IP configuration | `string` | n/a | yes |
 | <a name="input_public_ip_address_id"></a> [public\_ip\_address\_id](#input\_public\_ip\_address\_id) | The ID of the public IP address | `string` | `""` | no |
+| <a name="input_request_buffering_enabled"></a> [request\_buffering\_enabled](#input\_request\_buffering\_enabled) | Enable request buffering | `bool` | `true` | no |
 | <a name="input_resource_group_location"></a> [resource\_group\_location](#input\_resource\_group\_location) | The location of the resource group. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group. | `string` | n/a | yes |
+| <a name="input_response_buffering_enabled"></a> [response\_buffering\_enabled](#input\_response\_buffering\_enabled) | Enable response buffering | `bool` | `false` | no |
 | <a name="input_routing_rule_name"></a> [routing\_rule\_name](#input\_routing\_rule\_name) | Name for the routing\_rule | `string` | `null` | no |
 | <a name="input_ssl_policy_name"></a> [ssl\_policy\_name](#input\_ssl\_policy\_name) | Name of the SSL policy | `string` | `"AppGwSslPolicy20220101"` | no |
 | <a name="input_ssl_policy_type"></a> [ssl\_policy\_type](#input\_ssl\_policy\_type) | Type of the SSL policy | `string` | `"Predefined"` | no |

--- a/modules/azure-application-gateway/main.tf
+++ b/modules/azure-application-gateway/main.tf
@@ -18,6 +18,11 @@ resource "azurerm_application_gateway" "appgw" {
   resource_group_name = var.resource_group_name
   enable_http2        = true
 
+  global {
+    request_buffering_enabled  = var.request_buffering_enabled
+    response_buffering_enabled = var.response_buffering_enabled
+  }
+
   sku {
     name = var.gateway_sku
     tier = var.gateway_tier

--- a/modules/azure-application-gateway/module.yaml
+++ b/modules/azure-application-gateway/module.yaml
@@ -2,7 +2,7 @@
 name: azure-application-gateway
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-application-gateway
-version: 2.0.0
+version: 2.0.1
 changes:
-  - kind: fixed
-    description: "Explicitly state the version requirements for all providers"
+  - kind: added
+    description: "Application Gateway global settings for request and response buffering"

--- a/modules/azure-application-gateway/variables.tf
+++ b/modules/azure-application-gateway/variables.tf
@@ -205,3 +205,20 @@ variable "agw_diagnostic_name" {
   type        = string
   default     = null
 }
+
+variable "response_buffering_enabled" {
+  description = "Enable response buffering"
+  type        = bool
+  default     = false
+}
+
+variable "request_buffering_enabled" {
+  description = "Enable request buffering"
+  type        = bool
+  default     = true
+
+  validation {
+    condition     = var.request_buffering_enabled == true || var.gateway_sku != "WAF_v2"
+    error_message = "Request buffering cannot be disabled when using WAF_v2 SKU."
+  }
+}


### PR DESCRIPTION
## Describe your changes

This PR adds the ability to control the global settings for the request and response buffering on the Azure Application Gateway to the `azure-application-gateway` module.

- Response buffering can is disabled by default as it can interfere with websocket connection requests (specifically the event-socket requests).
- Request buffering is enabled by default and can only be disabled if the Application Gateway SKU is **not** `WAF_v2` (see [official docs from Microsoft](https://learn.microsoft.com/en-us/azure/application-gateway/proxy-buffers#limitations) on this)

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
