### PR TITLE
feat(platform): Add cognitive keys to sensitive keyvault

### DIFF
--- a/modules/azure-openai/README.md
+++ b/modules/azure-openai/README.md
@@ -46,6 +46,7 @@ No modules.
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault | `any` | `null` | no |
 | <a name="input_primary_access_key_secret_name_suffix"></a> [primary\_access\_key\_secret\_name\_suffix](#input\_primary\_access\_key\_secret\_name\_suffix) | The suffix of the secret name where the Primary Access Key is stored for the Cognitive Account. The secret name will be Cognitive Account Name + this suffix | `string` | `"-key"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
+| <a name="input_sens_key_vault_id"></a> [sens\_key\_vault\_id](#input\_sens\_key\_vault\_id) | The ID of the sensitive Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault | `any` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags for the resource | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/modules/azure-openai/README.md
+++ b/modules/azure-openai/README.md
@@ -46,7 +46,6 @@ No modules.
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault | `any` | `null` | no |
 | <a name="input_primary_access_key_secret_name_suffix"></a> [primary\_access\_key\_secret\_name\_suffix](#input\_primary\_access\_key\_secret\_name\_suffix) | The suffix of the secret name where the Primary Access Key is stored for the Cognitive Account. The secret name will be Cognitive Account Name + this suffix | `string` | `"-key"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group | `string` | n/a | yes |
-| <a name="input_sens_key_vault_id"></a> [sens\_key\_vault\_id](#input\_sens\_key\_vault\_id) | The ID of the sensitive Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault | `any` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags for the resource | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -5,4 +5,4 @@ sources:
 version: 2.0.1
 changes:
   - kind: fixed
-    description: "Correct used expression for default policy."
+    description: "Add cognitive keys to sensitive keyvault."

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -5,4 +5,4 @@ sources:
 version: 2.0.2
 changes:
   - kind: fixed
-    description: "Add cognitive keys to sensitive keyvault."
+    description: "Delete aca_with_local_auth variable as we would like to use a sensitive key vault"

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -2,7 +2,7 @@
 name: azure-openai
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-openai
-version: 2.0.1
+version: 2.0.2
 changes:
   - kind: fixed
     description: "Add cognitive keys to sensitive keyvault."

--- a/modules/azure-openai/secrets.tf
+++ b/modules/azure-openai/secrets.tf
@@ -1,18 +1,12 @@
 locals {
-  create_vault_secrets      = var.key_vault_id != null
-  create_vault_secrets_sens = var.sens_key_vault_id != null
-  # Filtered  cognitive accounts to include only those with a local auth enabled
-  aca_with_local_auth = {
-    for k, v in var.cognitive_accounts : k => v
-    if v.local_auth_enabled
-  }
+  create_vault_secrets = var.key_vault_id != null
 }
 
 resource "azurerm_key_vault_secret" "key" {
-  for_each     = local.create_vault_secrets_sens ? local.aca_with_local_auth : {}
+  for_each     = local.create_vault_secrets ? azurerm_cognitive_account.aca : {}
   name         = "${each.key}${var.primary_access_key_secret_name_suffix}"
   value        = azurerm_cognitive_account.aca[each.value.name].primary_access_key
-  key_vault_id = var.sens_key_vault_id
+  key_vault_id = var.key_vault_id
 }
 
 # Store the endpoint for each cognitive account in Key Vault

--- a/modules/azure-openai/secrets.tf
+++ b/modules/azure-openai/secrets.tf
@@ -1,5 +1,6 @@
 locals {
-  create_vault_secrets = var.key_vault_id != null
+  create_vault_secrets      = var.key_vault_id != null
+  create_vault_secrets_sens = var.sens_key_vault_id != null
   # Filtered  cognitive accounts to include only those with a local auth enabled
   aca_with_local_auth = {
     for k, v in var.cognitive_accounts : k => v
@@ -8,10 +9,10 @@ locals {
 }
 
 resource "azurerm_key_vault_secret" "key" {
-  for_each     = local.create_vault_secrets ? local.aca_with_local_auth : {}
+  for_each     = local.create_vault_secrets_sens ? local.aca_with_local_auth : {}
   name         = "${each.key}${var.primary_access_key_secret_name_suffix}"
   value        = azurerm_cognitive_account.aca[each.value.name].primary_access_key
-  key_vault_id = var.key_vault_id
+  key_vault_id = var.sens_key_vault_id
 }
 
 # Store the endpoint for each cognitive account in Key Vault

--- a/modules/azure-openai/variables.tf
+++ b/modules/azure-openai/variables.tf
@@ -53,11 +53,6 @@ variable "key_vault_id" {
   default     = null
 }
 
-variable "sens_key_vault_id" {
-  description = "The ID of the sensitive Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault"
-  default     = null
-}
-
 variable "endpoint_definitions_secret_name" {
   description = "Name of the secret for the endpoint definitions"
   default     = "azure-openai-endpoint-definitions"

--- a/modules/azure-openai/variables.tf
+++ b/modules/azure-openai/variables.tf
@@ -52,6 +52,12 @@ variable "key_vault_id" {
   description = "The ID of the Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault"
   default     = null
 }
+
+variable "sens_key_vault_id" {
+  description = "The ID of the sensitive Key Vault where to store the secrets. If not set, the secrets will not be stored in the Key Vault"
+  default     = null
+}
+
 variable "endpoint_definitions_secret_name" {
   description = "Name of the secret for the endpoint definitions"
   default     = "azure-openai-endpoint-definitions"


### PR DESCRIPTION
## Describe your changes

Currently, the cognitive keys are deployed in the core Key Vault instead of the sensitive one. These changes ensure that the keys are deployed to the sensitive Key Vault for enhanced security.


## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
