### PR TITLE
Feat/storage-account-data-protection-settings

### DIFF
--- a/modules/azure-defender/module.yaml
+++ b/modules/azure-defender/module.yaml
@@ -2,7 +2,7 @@
 name: azure-defender
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-defender
-version: 2.0.0-rc.1
+version: 2.0.0-rc.2
 changes:
   - kind: added
     description: "All Unique Azure Modules start off in the major version `2.0.0` as Unique already supported a lot of modules prior to the public repository which are summarized as `1.x`. Like that, it is easier to separate the modules that were already handed out from the modules that are new and will be handed out in the future."

--- a/modules/azure-defender/module.yaml
+++ b/modules/azure-defender/module.yaml
@@ -2,7 +2,7 @@
 name: azure-defender
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-defender
-version: 2.0.0-rc.2
+version: 2.0.0-rc.1
 changes:
   - kind: added
     description: "All Unique Azure Modules start off in the major version `2.0.0` as Unique already supported a lot of modules prior to the public repository which are summarized as `1.x`. Like that, it is easier to separate the modules that were already handed out from the modules that are new and will be handed out in the future."

--- a/modules/azure-storage-account/README.md
+++ b/modules/azure-storage-account/README.md
@@ -38,6 +38,40 @@ You can learn in the [Design principles](../../DESIGN.md) about the `perimeter` 
     + Contributor of the resource group
 - Read [Blob Storage feature support in Azure Storage accounts](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-feature-support-in-storage-accounts) to understand which combinations of values make sense and are supported
 
+## Security Features
+
+The storage account is configured with several security features enabled by default:
+
+- Shared access key authentication is disabled by default
+- Public network access is disabled by default
+- Minimum TLS version is set to 1.2
+- Nested items are not allowed to be public
+- HTTPS traffic only is enforced
+
+### Data Protection Settings
+
+The module includes comprehensive data protection features that can be configured through a single `data_protection_settings` object:
+
+```hcl
+data_protection_settings = {
+  blob_soft_delete_retention_days      = 7     # 1-365 days
+  container_soft_delete_retention_days = 7     # 1-365 days
+  versioning_enabled                   = true
+  change_feed_enabled                  = true
+  change_feed_retention_days           = 7     # 0-146000 days
+  point_in_time_restore_days           = 5     # 0-365 days
+}
+```
+
+Important notes about data protection settings:
+- When enabling point-in-time restore (days > 0):
+  - Versioning must be enabled
+  - Change feed must be enabled
+  - Blob soft delete retention must be enabled
+  - Restore days must be less than blob soft delete retention days
+- All retention periods have validated ranges to ensure compliance with Azure requirements
+- Default values are set to provide a good balance of protection while managing costs
+
 ## [Examples](./examples)
 
 ## Backups
@@ -96,20 +130,21 @@ No modules.
 | <a name="input_account_replication_type"></a> [account\_replication\_type](#input\_account\_replication\_type) | Type of replication to use for this storage account. Learn more about storage account replication types in the Azure Docs. | `string` | `"LRS"` | no |
 | <a name="input_account_tier"></a> [account\_tier](#input\_account\_tier) | Tier to use for the storage account. Learn more about storage account tiers in the Azure Docs. | `string` | `"Standard"` | no |
 | <a name="input_connection_settings"></a> [connection\_settings](#input\_connection\_settings) | Object containing the connection strings and the Key Vault secret ID where the connection strings will be stored | <pre>object({<br/>    connection_string_1 = string<br/>    connection_string_2 = string<br/>    key_vault_id        = string<br/>    expiration_date     = optional(string, "2099-12-31T23:59:59Z")<br/>  })</pre> | `null` | no |
-| <a name="input_container_deleted_retain_days"></a> [container\_deleted\_retain\_days](#input\_container\_deleted\_retain\_days) | Number of days to retain deleted containers. | `number` | `7` | no |
 | <a name="input_containers"></a> [containers](#input\_containers) | Map of containers to create in the storage account where the key is the name. | <pre>map(object({<br/>    access_type = optional(string, "private")<br/>  }))</pre> | `{}` | no |
 | <a name="input_cors_rules"></a> [cors\_rules](#input\_cors\_rules) | CORS rules for the storage account | <pre>list(object({<br/>    allowed_origins    = list(string)<br/>    allowed_methods    = list(string)<br/>    allowed_headers    = list(string)<br/>    exposed_headers    = list(string)<br/>    max_age_in_seconds = number<br/>  }))</pre> | `[]` | no |
-| <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key) | Customer managed key properties for the storage account. Refer to the readme for more information on what is needed to enable customer-managed key encryption. It is recommended to not use key\_version unless you have a specific reason to do so as leaving it out will allow automatic key rotation. The key\_vault\_id must be accessible to the user\_assigned\_identity\_id. | <pre>object({<br/>    key_name                  = string<br/>    key_vault_id              = string<br/>    key_version               = optional(string, null)<br/>    user_assigned_identity_id = string<br/>  })</pre> | `null` | no |
-| <a name="input_deleted_retain_days"></a> [deleted\_retain\_days](#input\_deleted\_retain\_days) | Number of days to retain deleted blobs. | `number` | `7` | no |
+| <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key) | Customer managed key properties for the storage account. Refer to the readme for more information on what is needed to enable customer-managed key encryption. | <pre>object({<br/>    key_name                  = string<br/>    key_vault_id              = string<br/>    key_version               = optional(string, null)<br/>    user_assigned_identity_id = string<br/>  })</pre> | `null` | no |
+| <a name="input_data_protection_settings"></a> [data\_protection\_settings](#input\_data\_protection\_settings) | Settings for data protection features including soft delete, versioning, change feed and point-in-time restore. | <pre>object({<br/>    blob_soft_delete_retention_days      = optional(number, 7)<br/>    container_soft_delete_retention_days = optional(number, 7)<br/>    versioning_enabled                   = optional(bool, true)<br/>    change_feed_enabled                  = optional(bool, true)<br/>    change_feed_retention_days           = optional(number, 7)<br/>    point_in_time_restore_days          = optional(number, 5)<br/>  })</pre> | <pre>{<br/>  blob_soft_delete_retention_days: 7,<br/>  container_soft_delete_retention_days: 7,<br/>  versioning_enabled: true,<br/>  change_feed_enabled: true,<br/>  change_feed_retention_days: 7,<br/>  point_in_time_restore_days: 5<br/>}</pre> | no |
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | List of managed identity IDs to assign to the storage account. | `list(string)` | `[]` | no |
-| <a name="input_is_nfs_mountable"></a> [is\_nfs\_mountable](#input\_is\_nfs\_mountable) | Enable NFSv3 and HNS protocol for the storage account in order to be mounted to AKS/nodes. In order to enable this, the account\_tier and the account\_kind must be set to a limited subset, refer to the Azure Docs(https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#is_hns_enabled-1) for more information. | `bool` | `false` | no |
+| <a name="input_is_nfs_mountable"></a> [is\_nfs\_mountable](#input\_is\_nfs\_mountable) | Enable NFSv3 and HNS protocol for the storage account in order to be mounted to AKS/nodes. | `bool` | `false` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location of the resources. | `string` | n/a | yes |
 | <a name="input_min_tls_version"></a> [min\_tls\_version](#input\_min\_tls\_version) | Minimum TLS version supported by the storage account. | `string` | `"TLS1_2"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the storage account. | `string` | n/a | yes |
 | <a name="input_network_rules"></a> [network\_rules](#input\_network\_rules) | Generally network rules should be managed outside this module, but when using `is_nfs_mountable` then a `network_rules` variable is required as Azure does not allow the creation of such accounts without `Deny`ing traffic from creation. | <pre>object({<br/>    virtual_network_subnet_ids = list(string)<br/>    ip_rules                   = list(string)<br/>    bypass                     = optional(list(string), ["Metrics", "Logging", "AzureServices"])<br/>    private_link_accesses = list(object({<br/>      endpoint_resource_id = string<br/>      endpoint_tenant_id   = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group to put the resources in. | `string` | n/a | yes |
-| <a name="input_self_cmk"></a> [self\_cmk](#input\_self\_cmk) | Details for the self customer managed key. | <pre>object({<br/>    key_name                  = string<br/>    key_vault_id              = string<br/>    key_type                  = optional(string, "RSA-HSM")<br/>    key_size                  = optional(number, 2048)<br/>    key_opts                  = optional(list(string), ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"])<br/>    user_assigned_identity_id = string<br/><br/>  })</pre> | `null` | no |
-| <a name="input_storage_management_policy_default"></a> [storage\_management\_policy\_default](#input\_storage\_management\_policy\_default) | A simple abstraction of the most common properties for storage management lifecycle policies. If the simple implementation does not meet your needs, please open an issue. If you use this module to safe files that are rarely to never accessed again, opt for a very aggressive policy (starting already cool and archiving early). If you want to implement your own storage management policy, disable the default and use the output storage\_account\_id to implement your own policies. | <pre>object({<br/>    enabled                                  = optional(bool, true)<br/>    blob_to_cool_after_last_modified_days    = optional(number, 10)<br/>    blob_to_cold_after_last_modified_days    = optional(number, 50)<br/>    blob_to_archive_after_last_modified_days = optional(number, 100)<br/>    blob_to_deleted_after_last_modified_days = optional(number, 730)<br/>  })</pre> | <pre>{<br/>  "blob_to_archive_after_last_modified_days": 100,<br/>  "blob_to_cold_after_last_modified_days": 50,<br/>  "blob_to_cool_after_last_modified_days": 10,<br/>  "blob_to_deleted_after_last_modified_days": 730,<br/>  "enabled": true<br/>}</pre> | no |
+| <a name="input_self_cmk"></a> [self\_cmk](#input\_self\_cmk) | Details for the self customer managed key. | <pre>object({<br/>    key_name                  = string<br/>    key_vault_id              = string<br/>    key_type                  = optional(string, "RSA-HSM")<br/>    key_size                  = optional(number, 2048)<br/>    key_opts                  = optional(list(string), ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"])<br/>    user_assigned_identity_id = string<br/>  })</pre> | `null` | no |
+| <a name="input_shared_access_key_enabled"></a> [shared\_access\_key\_enabled](#input\_shared\_access\_key\_enabled) | Enable shared access key for the storage account. | `bool` | `false` | no |
+| <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Enable public network access for the storage account. | `bool` | `false` | no |
+| <a name="input_storage_management_policy_default"></a> [storage\_management\_policy\_default](#input\_storage\_management\_policy\_default) | A simple abstraction of the most common properties for storage management lifecycle policies. | <pre>object({<br/>    enabled                                  = optional(bool, true)<br/>    blob_to_cool_after_last_modified_days    = optional(number, 10)<br/>    blob_to_cold_after_last_modified_days    = optional(number, 50)<br/>    blob_to_archive_after_last_modified_days = optional(number, 100)<br/>    blob_to_deleted_after_last_modified_days = optional(number, 730)<br/>  })</pre> | <pre>{<br/>  enabled: true,<br/>  blob_to_cool_after_last_modified_days: 10,<br/>  blob_to_cold_after_last_modified_days: 50,<br/>  blob_to_archive_after_last_modified_days: 100,<br/>  blob_to_deleted_after_last_modified_days: 730<br/>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for the resources. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -123,5 +158,4 @@ No modules.
 ## Limitations
 
 - This module as of now is not supporting [`azurerm_key_vault_managed_hardware_security_module` (HSM-backend Key Vaults)](https://registry.terraform.io/providers/hashicorp/azurerm/3.117.0/docs/resources/key_vault_managed_hardware_security_module).
-- Neither change feed nor versioning are currently supported by this module. If you need these features, please open an issue. They are omitted for brevity and simplicity not because we do not want to support them.
 - Future versions will ship with built-in [`azurerm_storage_container_immutability_policy`](https://registry.terraform.io/providers/hashicorp/azurerm/3.117.0/docs/resources/storage_container_immutability_policy).

--- a/modules/azure-storage-account/main.tf
+++ b/modules/azure-storage-account/main.tf
@@ -19,6 +19,8 @@ resource "azurerm_storage_account" "storage_account" {
   allow_nested_items_to_be_public = false
   https_traffic_only_enabled      = true
   min_tls_version                 = var.min_tls_version
+  shared_access_key_enabled       = var.shared_access_key_enabled
+  public_network_access_enabled   = var.public_network_access_enabled
 
   # enable mounting account as disk
   nfsv3_enabled  = var.is_nfs_mountable
@@ -26,6 +28,10 @@ resource "azurerm_storage_account" "storage_account" {
 
   # enable access from browsers
   blob_properties {
+    change_feed_enabled           = var.data_protection_settings.change_feed_enabled
+    change_feed_retention_in_days = var.data_protection_settings.change_feed_retention_days > 0 ? var.data_protection_settings.change_feed_retention_days : null
+    versioning_enabled            = var.data_protection_settings.versioning_enabled
+
     dynamic "cors_rule" {
       for_each = var.cors_rules
       content {
@@ -38,19 +44,27 @@ resource "azurerm_storage_account" "storage_account" {
     }
 
     dynamic "container_delete_retention_policy" {
-      for_each = var.container_deleted_retain_days > 0 ? [1] : []
+      for_each = var.data_protection_settings.container_soft_delete_retention_days > 0 ? [1] : []
       content {
-        days = var.container_deleted_retain_days
+        days = var.data_protection_settings.container_soft_delete_retention_days
       }
     }
 
     dynamic "delete_retention_policy" {
-      for_each = var.deleted_retain_days > 0 ? [1] : []
+      for_each = var.data_protection_settings.blob_soft_delete_retention_days > 0 ? [1] : []
       content {
-        days                     = var.deleted_retain_days
+        days                     = var.data_protection_settings.blob_soft_delete_retention_days
         permanent_delete_enabled = false
       }
     }
+
+    dynamic "restore_policy" {
+      for_each = var.data_protection_settings.point_in_time_restore_days > 0 ? [1] : []
+      content {
+        days = var.data_protection_settings.point_in_time_restore_days
+      }
+    }
+
   }
 
   identity {

--- a/modules/azure-storage-account/module.yaml
+++ b/modules/azure-storage-account/module.yaml
@@ -2,7 +2,9 @@
 name: azure-storage-account
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-storage-account
-version: 2.0.2
+version: 3.0.0
 changes:
+  - kind: changed
+    description: "Breaking change in variables: data_protection_settings is now one object with multiple properties."
   - kind: changed
     description: "Required azurerm provider version is now ~> 4.15"


### PR DESCRIPTION
## Describe your changes
Added `data_protection_settings` object to add point-in-time restore capabilities in combination with validations to the variables. Soft-delete and point-in-time restore capabilities are activated by default.

Also added possibility to configure SAS and public network access and deactivated them by default.

This makes the storage account more robust against accidental and malicious tampering.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
