### PR TITLE
feat(app-reg): make KV storage optional

### DIFF
--- a/modules/azure-entra-app-registration/README.md
+++ b/modules/azure-entra-app-registration/README.md
@@ -37,9 +37,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aad-app-secret-display-name"></a> [aad-app-secret-display-name](#input\_aad-app-secret-display-name) | The displayed name in kv | `string` | n/a | yes |
+| <a name="input_client_secret_generation_config"></a> [client\_secret\_generation\_config](#input\_client\_secret\_generation\_config) | When enabled, a client secret will be generated and stored in the keyvault. | <pre>object({<br/>    enabled     = bool<br/>    keyvault_id = optional(string)<br/>    secret_name = optional(string, "entra-app-client-secret")<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The displayed name in Entra | `string` | n/a | yes |
-| <a name="input_keyvault_id"></a> [keyvault\_id](#input\_keyvault\_id) | Keyvault where to store the app credentials | `string` | n/a | yes |
 | <a name="input_maintainers_principal_object_ids"></a> [maintainers\_principal\_object\_ids](#input\_maintainers\_principal\_object\_ids) | The object ids of the user/groups/service\_principal | `list(string)` | n/a | yes |
 | <a name="input_owner_user_object_ids"></a> [owner\_user\_object\_ids](#input\_owner\_user\_object\_ids) | n/a | `list(string)` | `[]` | no |
 | <a name="input_redirect_uris"></a> [redirect\_uris](#input\_redirect\_uris) | Authorized redirects | `list(string)` | `[]` | no |

--- a/modules/azure-entra-app-registration/examples/simple/main.tf
+++ b/modules/azure-entra-app-registration/examples/simple/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+module "entra_app" {
+  source = "../.."
+  client_secret_generation_config = {
+    enabled = false
+  }
+  display_name                     = "example-app"
+  maintainers_principal_object_ids = ["00000000-0000-0000-0000-000000000000"]
+}

--- a/modules/azure-entra-app-registration/module.yaml
+++ b/modules/azure-entra-app-registration/module.yaml
@@ -1,8 +1,7 @@
-
 name: azure-entra-app-registration
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-entra-app-registration
-version: 2.0.0-rc.3
+version: 2.0.0
 changes:
-  - kind: fixed
-    description: "Explicitly state the version requirements for all providers"
+  - kind: changed
+    description: "Client secret generation is now optional in cases where Key Vault output is not needed or desired."

--- a/modules/azure-entra-app-registration/provider.tf
+++ b/modules/azure-entra-app-registration/provider.tf
@@ -3,9 +3,8 @@ terraform {
   required_version = ">= 1.5"
   required_providers {
     azurerm = {
-      source   = "hashicorp/azurerm"
-      version  = "~> 4.15"
-      features = {}
+      source  = "hashicorp/azurerm"
+      version = "~> 4.15"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/azure-entra-app-registration/provider.tf
+++ b/modules/azure-entra-app-registration/provider.tf
@@ -3,8 +3,9 @@ terraform {
   required_version = ">= 1.5"
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.15"
+      source   = "hashicorp/azurerm"
+      version  = "~> 4.15"
+      features = {}
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/azure-entra-app-registration/secrets.tf
+++ b/modules/azure-entra-app-registration/secrets.tf
@@ -1,16 +1,19 @@
 resource "azuread_application_password" "aad_app_password" {
+  count          = var.client_secret_generation_config.enabled ? 1 : 0
   application_id = azuread_application.this.id
   display_name   = "unique-enterprise-gitops-app-key"
 }
 
 resource "azurerm_key_vault_secret" "aad_app_gitops_client_id" {
-  name         = "aad-app-${var.aad-app-secret-display-name}-client-id"
+  count        = var.client_secret_generation_config.enabled && var.client_secret_generation_config.keyvault_id != null ? 1 : 0
+  name         = "aad-app-${var.client_secret_generation_config.secret_name}-client-id"
   value        = azuread_application.this.client_id
-  key_vault_id = var.keyvault_id
+  key_vault_id = var.client_secret_generation_config.keyvault_id
 }
 
 resource "azurerm_key_vault_secret" "aad_app_gitops_client_secret" {
-  name         = "aad-app-${var.aad-app-secret-display-name}-client-secret"
-  value        = azuread_application_password.aad_app_password.value
-  key_vault_id = var.keyvault_id
+  count        = var.client_secret_generation_config.enabled && var.client_secret_generation_config.keyvault_id != null ? 1 : 0
+  name         = "aad-app-${var.client_secret_generation_config.secret_name}-client-secret"
+  value        = azuread_application_password.aad_app_password[0].value
+  key_vault_id = var.client_secret_generation_config.keyvault_id
 }

--- a/modules/azure-entra-app-registration/variables.tf
+++ b/modules/azure-entra-app-registration/variables.tf
@@ -3,14 +3,21 @@ variable "display_name" {
   description = "The displayed name in Entra"
 }
 
-variable "aad-app-secret-display-name" {
-  type        = string
-  description = "The displayed name in kv"
-}
+variable "client_secret_generation_config" {
+  type = object({
+    enabled     = bool
+    keyvault_id = optional(string)
+    secret_name = optional(string, "entra-app-client-secret")
+  })
+  description = "When enabled, a client secret will be generated and stored in the keyvault."
+  default = {
+    enabled = false
+  }
 
-variable "keyvault_id" {
-  type        = string
-  description = "Keyvault where to store the app credentials"
+  validation {
+    condition     = !var.client_secret_generation_config.enabled || (var.client_secret_generation_config.enabled && var.client_secret_generation_config.keyvault_id != null)
+    error_message = "When client_secret_generation_config.enabled is true, keyvault_id must be provided."
+  }
 }
 
 variable "redirect_uris" {
@@ -54,34 +61,6 @@ variable "required_resource_access_list" {
         id   = "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0" # email
         type = "Scope"
       },
-      #   {
-      #     id   = "aa85bf13-d771-4d5d-a9e6-bca04ce44edf" # TeamsAppInstallation.ReadWriteForChat
-      #     type = "Scope"
-      #   },
-      #   {
-      #     id   = "ee928332-e9c2-4747-b4a0-f8c164b68de6" # TeamsTab.ReadWriteForChat
-      #     type = "Scope"
-      #   },
-      #   {
-      #     id   = "465a38f9-76ea-45b9-9f34-9e8b0d4b0b42" # Calendars.Read
-      #     type = "Scope"
-      #   },
-      #   {
-      #     id   = "f501c180-9344-439a-bca0-6cbf209fd270" # Chat.Read
-      #     type = "Scope"
-      #   },
-      #   {
-      #     id   = "ff74d97f-43af-4b68-9f2a-b77ee6968c5d" # Contacts.Read
-      #     type = "Scope"
-      #   },
-      #   {
-      #     id   = "7427e0e9-2fba-42fe-b0c0-848c9e6a8182" # offline_access
-      #     type = "Scope"
-      #   },
-      #   {
-      #     id   = "a65f2972-a4f8-4f5e-afd7-69ccb046d5dc" # OnlineMeetings.ReadWrite
-      #     type = "Scope"
-      #   }
     ],
   }
 }


### PR DESCRIPTION
## Describe your changes

We have clusters where we do not natively want to store the secret in KV but generate it once in the portal then store it somewhere else (on-prem clusters).

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
