### PR TITLE
feat(agw): added support for configuring private ip config for http listener

### DIFF
--- a/modules/azure-application-gateway/README.md
+++ b/modules/azure-application-gateway/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Maximum capacity for autoscaling | `number` | `2` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Minimum capacity for autoscaling | `number` | `1` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for naming resources | `string` | n/a | yes |
+| <a name="input_private_frontend_enabled"></a> [private\_frontend\_enabled](#input\_private\_frontend\_enabled) | Enable the private frontend IP configuration for the http listener. If disabled, uses public frontend IP configuration | `bool` | `false` | no |
 | <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | Private IP address for the frontend IP configuration | `string` | n/a | yes |
 | <a name="input_public_ip_address_id"></a> [public\_ip\_address\_id](#input\_public\_ip\_address\_id) | The ID of the public IP address | `string` | `""` | no |
 | <a name="input_request_buffering_enabled"></a> [request\_buffering\_enabled](#input\_request\_buffering\_enabled) | Enable request buffering | `bool` | `true` | no |

--- a/modules/azure-application-gateway/main.tf
+++ b/modules/azure-application-gateway/main.tf
@@ -69,7 +69,7 @@ resource "azurerm_application_gateway" "appgw" {
 
   http_listener {
     name                           = local.http_listener_name
-    frontend_ip_configuration_name = local.frontend_ip_config_name
+    frontend_ip_configuration_name = var.private_frontend_enabled ? local.frontend_ip_private_config_name : local.frontend_ip_config_name
     frontend_port_name             = local.frontend_port_name
     protocol                       = "Http"
   }

--- a/modules/azure-application-gateway/module.yaml
+++ b/modules/azure-application-gateway/module.yaml
@@ -2,7 +2,7 @@
 name: azure-application-gateway
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-application-gateway
-version: 2.0.1
+version: 2.1.0
 changes:
   - kind: added
-    description: "Application Gateway global settings for request and response buffering"
+    description: "Support for configuring http listener to use private frontend IP configuration"

--- a/modules/azure-application-gateway/variables.tf
+++ b/modules/azure-application-gateway/variables.tf
@@ -222,3 +222,9 @@ variable "request_buffering_enabled" {
     error_message = "Request buffering cannot be disabled when using WAF_v2 SKU."
   }
 }
+
+variable "private_frontend_enabled" {
+  description = "Enable the private frontend IP configuration for the http listener. If disabled, uses public frontend IP configuration"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Describe your changes

Adds support for configuring http listener to use private frontend IP configuration instead of public one.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [ ] Pre-Commit passed or has been run manually (`Makefile`) -> Note: broken locally for me currently
