### PR TITLE
fix(agw): update IP address reference in WAF policy match values

### DIFF
--- a/modules/azure-application-gateway/module.yaml
+++ b/modules/azure-application-gateway/module.yaml
@@ -1,7 +1,9 @@
 name: azure-application-gateway
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-application-gateway
-version: 2.1.1
+version: 2.1.2
 changes:
   - kind: fixed
     description: "ip_name is now optional as when a public_ip_address_id is provided the name is not needed."
+  - kind: fixed
+    description: "Fixed WAF policy to correctly reference the Application Gateway's public IP resource."

--- a/modules/azure-application-gateway/waf.tf
+++ b/modules/azure-application-gateway/waf.tf
@@ -86,7 +86,7 @@ resource "azurerm_web_application_firewall_policy" "wafpolicy" {
         }
         operator           = "IPMatch"
         negation_condition = true
-        match_values       = concat(custom_rules.value.list, ["${azurerm_public_ip.this.ip_address}"])
+        match_values       = concat(custom_rules.value.list, ["${azurerm_public_ip.appgw[0].ip_address}"])
       }
 
       action = "Block"


### PR DESCRIPTION
Updated the match values in the WAF policy to reference the correct public IP address from the Application Gateway module, ensuring proper functionality of the firewall rules.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)

## Describe your changes

<!-- Describe your changes in detail -->

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated (`module.yaml`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
