### PR TITLE
feat(var): add resource outputs for rbac

### DIFF
--- a/modules/azure-document-intelligence/README.md
+++ b/modules/azure-document-intelligence/README.md
@@ -56,6 +56,7 @@ No modules.
 |------|-------------|
 | <a name="output_azure_document_intelligence_endpoint_definitions"></a> [azure\_document\_intelligence\_endpoint\_definitions](#output\_azure\_document\_intelligence\_endpoint\_definitions) | Object containing list of objects containing endpoint definitions with name, endpoint and location |
 | <a name="output_azure_document_intelligence_endpoints"></a> [azure\_document\_intelligence\_endpoints](#output\_azure\_document\_intelligence\_endpoints) | Object containing list of endpoints |
+| <a name="output_cognitive_account_resource"></a> [cognitive\_account\_resource](#output\_cognitive\_account\_resource) | The properties of the Cognitive Services Account. |
 | <a name="output_endpoint_definitions_secret_name"></a> [endpoint\_definitions\_secret\_name](#output\_endpoint\_definitions\_secret\_name) | Name of the secret containing the list of objects containing endpoint definitions with name, endpoint and location (content of `azure_document_intelligence_endpoint_definitions` output). Returns null if Key Vault integration is disabled |
 | <a name="output_endpoints_secret_name"></a> [endpoints\_secret\_name](#output\_endpoints\_secret\_name) | Name of the secret containing the list of endpoints. Returns null if Key Vault integration is disabled |
 | <a name="output_keys_secret_names"></a> [keys\_secret\_names](#output\_keys\_secret\_names) | List of names of the secrets containing the primary access key to connect to the endpoints. Returns null if Key Vault integration is disabled |

--- a/modules/azure-document-intelligence/module.yaml
+++ b/modules/azure-document-intelligence/module.yaml
@@ -1,11 +1,9 @@
 name: azure-document-intelligence
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-document-intelligence
-version: 3.0.0
+version: 3.0.1
 compatibility:
   unique.ai: ~> 2025.16
 changes:
-  - kind: changed
-    description: "user_assigned_identity_ids is removed, the resource does not leverage any identity"
-  - kind: changed
-    description: "⚠️ accounts.[].local_auth_enabled and accounts.[].public_network_access_enabled default to false #secureByDefault"
+  - kind: added
+    description: "Outputs the cognitive services account properties for data sourcing."

--- a/modules/azure-document-intelligence/outputs.tf
+++ b/modules/azure-document-intelligence/outputs.tf
@@ -23,3 +23,7 @@ output "keys_secret_names" {
   description = "List of names of the secrets containing the primary access key to connect to the endpoints. Returns null if Key Vault integration is disabled"
   value       = local.create_vault_secrets ? [for k, v in azurerm_key_vault_secret.key : v.name] : null
 }
+output "cognitive_account_resource" {
+  description = "The properties of the Cognitive Services Account."
+  value       = azurerm_cognitive_account.aca
+}

--- a/modules/azure-kubernetes-service/README.md
+++ b/modules/azure-kubernetes-service/README.md
@@ -246,6 +246,7 @@ No modules.
 |------|-------------|
 | <a name="output_agic_identity_client_id"></a> [agic\_identity\_client\_id](#output\_agic\_identity\_client\_id) | The client ID of the identity used by the Application Gateway Ingress Controller. |
 | <a name="output_agic_identity_object_id"></a> [agic\_identity\_object\_id](#output\_agic\_identity\_object\_id) | The object ID of the identity used by the Application Gateway Ingress Controller. |
+| <a name="output_cluster_resource"></a> [cluster\_resource](#output\_cluster\_resource) | The properties of the Kubernetes cluster. |
 | <a name="output_csi_identity_client_id"></a> [csi\_identity\_client\_id](#output\_csi\_identity\_client\_id) | The client ID of the identity used by the CSI driver. |
 | <a name="output_csi_identity_object_id"></a> [csi\_identity\_object\_id](#output\_csi\_identity\_object\_id) | The object ID of the identity used by the CSI driver. |
 | <a name="output_csi_user_assigned_identity_name"></a> [csi\_user\_assigned\_identity\_name](#output\_csi\_user\_assigned\_identity\_name) | The name of the user-assigned identity for the CSI driver. Prefer using the csi\_identity\_client\_id and csi\_identity\_object\_id outputs as they are more reliable. |

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -3,11 +3,9 @@ sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-kubernetes-service
 # Next major release open changes:
 # - node_pool_settings.node_count should be removed
-version: 3.1.0
+version: 3.1.1
+compatibility:
+  unique.ai: ~> 2025.16
 changes:
   - kind: added
-    description: "Outputs the created ingress application gateway identity properties as agic_identity_client_id and agic_identity_object_id."
-  - kind: added
-    description: "Outputs the created csi driver identity properties as csi_identity_client_id and csi_identity_object_id."
-  - kind: added
-    description: "Docs to list SKUs."
+    description: "Outputs the cluster properties for data sourcing."

--- a/modules/azure-kubernetes-service/outputs.tf
+++ b/modules/azure-kubernetes-service/outputs.tf
@@ -42,3 +42,8 @@ output "csi_identity_object_id" {
   description = "The object ID of the identity used by the CSI driver."
   value       = azurerm_kubernetes_cluster.cluster.key_vault_secrets_provider[0].secret_identity[0].object_id
 }
+
+output "cluster_resource" {
+  description = "The properties of the Kubernetes cluster."
+  value       = azurerm_kubernetes_cluster.cluster
+}

--- a/modules/azure-openai/README.md
+++ b/modules/azure-openai/README.md
@@ -54,6 +54,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_cognitive_account_endpoints"></a> [cognitive\_account\_endpoints](#output\_cognitive\_account\_endpoints) | The endpoints used to connect to the Cognitive Service Account. |
+| <a name="output_cognitive_account_resources"></a> [cognitive\_account\_resources](#output\_cognitive\_account\_resources) | Map of Cognitive Service Accounts where keys are the account names. |
 | <a name="output_endpoints_secret_names"></a> [endpoints\_secret\_names](#output\_endpoints\_secret\_names) | List of secret names containing the endpoints for each Cognitive Service Account. Returns null if Key Vault integration is disabled. |
 | <a name="output_keys_secret_names"></a> [keys\_secret\_names](#output\_keys\_secret\_names) | List of secret names containing the access keys for each Cognitive Service Account. Returns null if Key Vault integration is disabled. |
 | <a name="output_model_version_endpoint_secret_name"></a> [model\_version\_endpoint\_secret\_name](#output\_model\_version\_endpoint\_secret\_name) | Name of the secret containing the model version endpoint definitions. Returns null if Key Vault integration is disabled. |

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -1,7 +1,9 @@
 name: azure-openai
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-openai
-version: 2.1.0
+version: 2.1.1
+compatibility:
+  unique.ai: ~> 2025.16
 changes:
   - kind: added
-    description: "Private endpoint configuration"
+    description: "Outputs the cognitive services accounts properties for data sourcing."

--- a/modules/azure-openai/outputs.tf
+++ b/modules/azure-openai/outputs.tf
@@ -23,3 +23,8 @@ output "keys_secret_names" {
   description = "List of secret names containing the access keys for each Cognitive Service Account. Returns null if Key Vault integration is disabled."
   value       = local.create_vault_secrets ? [for k, v in azurerm_key_vault_secret.key : v.name] : null
 }
+
+output "cognitive_account_resources" {
+  description = "Map of Cognitive Service Accounts where keys are the account names."
+  value       = { for name, account in azurerm_cognitive_account.aca : account.name => account }
+}


### PR DESCRIPTION
## Describe your changes

Most TF modules expose the resource for further consumption.
We only need the resource ids for RBAC but I don't want to make 200 other PRs for stuff. So we expose now the created resource as well.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
