### PR TITLE
feat(entra-app-reg): add hierarchical assignments

### DIFF
--- a/modules/azure-entra-app-registration/README.md
+++ b/modules/azure-entra-app-registration/README.md
@@ -28,11 +28,13 @@ No modules.
 | [azuread_app_role_assignment.infrastructure_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_app_role_assignment.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_app_role_assignment.system_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
+| [azuread_app_role_assignment.user](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_application_app_role.application_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_app_role.infrastructure_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_app_role.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_app_role.system_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
+| [azuread_application_app_role.user](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_password.aad_app_password](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
 | [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azurerm_key_vault_secret.aad_app_gitops_client_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
@@ -41,6 +43,7 @@ No modules.
 | [random_uuid.infrastructure_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.maintainers](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.system_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [random_uuid.user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 
 ## Inputs
 
@@ -56,6 +59,7 @@ No modules.
 | <a name="input_required_resource_access_list"></a> [required\_resource\_access\_list](#input\_required\_resource\_access\_list) | A map of resource\_app\_ids with their access configurations. | <pre>map(list(object({<br/>    id   = string<br/>    type = string<br/>  })))</pre> | <pre>{<br/>  "00000003-0000-0000-c000-000000000000": [<br/>    {<br/>      "id": "14dad69e-099b-42c9-810b-d002981feec1",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "37f7f235-527c-4136-accd-4a02d197296e",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",<br/>      "type": "Scope"<br/>    }<br/>  ]<br/>}</pre> | no |
 | <a name="input_role_assignments_required"></a> [role\_assignments\_required](#input\_role\_assignments\_required) | Whether role assignments are required to be able to use the app. Least privilege principle encourages true. | `bool` | `true` | no |
 | <a name="input_system_support_object_ids"></a> [system\_support\_object\_ids](#input\_system\_support\_object\_ids) | The object ids of the user/groups that should be able to support the system or core of the platform. Roles trickle down so this role includes application support. | `list(string)` | `[]` | no |
+| <a name="input_user_object_ids"></a> [user\_object\_ids](#input\_user\_object\_ids) | The object ids of the user/groups that should be able to just use the application/login. | `list(string)` | `[]` | no |
 
 ## Outputs
 
@@ -92,6 +96,7 @@ Version `3.0.0` introduces significant changes to how application roles and perm
 
       display_name = "My Application"
     - maintainers_principal_object_ids = ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"]
+    + user_object_ids                = ["00000000-0000-0000-0000-000000000002"]
     + application_support_object_ids = ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"]
     + # Optionally add system_support_object_ids = [...]
     + # Optionally add infrastructure_support_object_ids = [...]
@@ -110,6 +115,7 @@ Version `3.0.0` introduces significant changes to how application roles and perm
 
 *   A new boolean variable `role_assignments_required` has been added. It defaults to `true`.
 *   When `true`, users must be assigned one of the defined app roles (`application_support`, `system_support`, or `infrastructure_support`) to successfully sign in to the application. This enforces the principle of least privilege.
+*   If you'd like users to just be able to login, use `user_object_ids`.
 *   **Action Required:** If your application does *not* require users to have specific roles assigned for login, explicitly set `role_assignments_required = false`.
 
 #### Minor Changes

--- a/modules/azure-entra-app-registration/README.md
+++ b/modules/azure-entra-app-registration/README.md
@@ -24,26 +24,16 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_app_role_assignment.application_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
-| [azuread_app_role_assignment.infrastructure_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_app_role_assignment.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
-| [azuread_app_role_assignment.system_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
-| [azuread_app_role_assignment.user](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
+| [azuread_app_role_assignment.standard](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
-| [azuread_application_app_role.application_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
-| [azuread_application_app_role.infrastructure_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_app_role.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
-| [azuread_application_app_role.system_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
-| [azuread_application_app_role.user](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
+| [azuread_application_app_role.standard](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_password.aad_app_password](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
 | [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azurerm_key_vault_secret.aad_app_gitops_client_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.aad_app_gitops_client_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
-| [random_uuid.application_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
-| [random_uuid.infrastructure_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.maintainers](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
-| [random_uuid.system_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
-| [random_uuid.user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 
 ## Inputs
 
@@ -52,14 +42,18 @@ No modules.
 | <a name="input_application_support_object_ids"></a> [application\_support\_object\_ids](#input\_application\_support\_object\_ids) | The object ids of the user/groups that should be able to support the application. | `list(string)` | `[]` | no |
 | <a name="input_client_secret_generation_config"></a> [client\_secret\_generation\_config](#input\_client\_secret\_generation\_config) | When enabled, a client secret will be generated and stored in the keyvault. | <pre>object({<br/>    enabled     = bool<br/>    keyvault_id = optional(string)<br/>    secret_name = optional(string, "entra-app-client-secret")<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The displayed name in Entra ID. | `string` | n/a | yes |
+| <a name="input_homepage_url"></a> [homepage\_url](#input\_homepage\_url) | The homepage url of the app. | `string` | `"https://www.unique.ai"` | no |
 | <a name="input_infrastructure_support_object_ids"></a> [infrastructure\_support\_object\_ids](#input\_infrastructure\_support\_object\_ids) | The object ids of the user/groups that should be able to support the infrastructure of the platform. Roles trickle down so this role includes both system and application support. | `list(string)` | `[]` | no |
 | <a name="input_owner_user_object_ids"></a> [owner\_user\_object\_ids](#input\_owner\_user\_object\_ids) | n/a | `list(string)` | `[]` | no |
+| <a name="input_privacy_statement_url"></a> [privacy\_statement\_url](#input\_privacy\_statement\_url) | The privacy statement url of the app. | `string` | `"https://www.unique.ai/privacy"` | no |
 | <a name="input_redirect_uris"></a> [redirect\_uris](#input\_redirect\_uris) | Authorized redirects | `list(string)` | `[]` | no |
 | <a name="input_redirect_uris_public_native"></a> [redirect\_uris\_public\_native](#input\_redirect\_uris\_public\_native) | Public client/native (mobile & desktop) redirects | `list(string)` | `[]` | no |
 | <a name="input_required_resource_access_list"></a> [required\_resource\_access\_list](#input\_required\_resource\_access\_list) | A map of resource\_app\_ids with their access configurations. | <pre>map(list(object({<br/>    id   = string<br/>    type = string<br/>  })))</pre> | <pre>{<br/>  "00000003-0000-0000-c000-000000000000": [<br/>    {<br/>      "id": "14dad69e-099b-42c9-810b-d002981feec1",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "37f7f235-527c-4136-accd-4a02d197296e",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",<br/>      "type": "Scope"<br/>    }<br/>  ]<br/>}</pre> | no |
 | <a name="input_role_assignments_required"></a> [role\_assignments\_required](#input\_role\_assignments\_required) | Whether role assignments are required to be able to use the app. Least privilege principle encourages true. | `bool` | `true` | no |
+| <a name="input_sign_in_audience"></a> [sign\_in\_audience](#input\_sign\_in\_audience) | The audience of the app. | `string` | `"AzureADMyOrg"` | no |
 | <a name="input_system_support_object_ids"></a> [system\_support\_object\_ids](#input\_system\_support\_object\_ids) | The object ids of the user/groups that should be able to support the system or core of the platform. Roles trickle down so this role includes application support. | `list(string)` | `[]` | no |
-| <a name="input_user_object_ids"></a> [user\_object\_ids](#input\_user\_object\_ids) | The object ids of the user/groups that should be able to just use the application/login. | `list(string)` | `[]` | no |
+| <a name="input_terms_of_service_url"></a> [terms\_of\_service\_url](#input\_terms\_of\_service\_url) | The terms of service url of the app. | `string` | `"https://www.unique.ai/terms"` | no |
+| <a name="input_user_object_ids"></a> [user\_object\_ids](#input\_user\_object\_ids) | The object ids of the user/groups that should be able to just use the application/login. All support profiles will be added to this list. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/azure-entra-app-registration/README.md
+++ b/modules/azure-entra-app-registration/README.md
@@ -24,28 +24,97 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azuread_app_role_assignment.application_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
+| [azuread_app_role_assignment.infrastructure_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_app_role_assignment.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
+| [azuread_app_role_assignment.system_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_application_app_role.application_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
+| [azuread_application_app_role.infrastructure_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_app_role.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
+| [azuread_application_app_role.system_support](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_password.aad_app_password](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
 | [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azurerm_key_vault_secret.aad_app_gitops_client_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.aad_app_gitops_client_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [random_uuid.application_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [random_uuid.infrastructure_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [random_uuid.maintainers](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [random_uuid.system_support](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_application_support_object_ids"></a> [application\_support\_object\_ids](#input\_application\_support\_object\_ids) | The object ids of the user/groups that should be able to support the application. | `list(string)` | `[]` | no |
 | <a name="input_client_secret_generation_config"></a> [client\_secret\_generation\_config](#input\_client\_secret\_generation\_config) | When enabled, a client secret will be generated and stored in the keyvault. | <pre>object({<br/>    enabled     = bool<br/>    keyvault_id = optional(string)<br/>    secret_name = optional(string, "entra-app-client-secret")<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
-| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The displayed name in Entra | `string` | n/a | yes |
-| <a name="input_maintainers_principal_object_ids"></a> [maintainers\_principal\_object\_ids](#input\_maintainers\_principal\_object\_ids) | The object ids of the user/groups/service\_principal | `list(string)` | n/a | yes |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The displayed name in Entra ID. | `string` | n/a | yes |
+| <a name="input_infrastructure_support_object_ids"></a> [infrastructure\_support\_object\_ids](#input\_infrastructure\_support\_object\_ids) | The object ids of the user/groups that should be able to support the infrastructure of the platform. Roles trickle down so this role includes both system and application support. | `list(string)` | `[]` | no |
 | <a name="input_owner_user_object_ids"></a> [owner\_user\_object\_ids](#input\_owner\_user\_object\_ids) | n/a | `list(string)` | `[]` | no |
 | <a name="input_redirect_uris"></a> [redirect\_uris](#input\_redirect\_uris) | Authorized redirects | `list(string)` | `[]` | no |
 | <a name="input_redirect_uris_public_native"></a> [redirect\_uris\_public\_native](#input\_redirect\_uris\_public\_native) | Public client/native (mobile & desktop) redirects | `list(string)` | `[]` | no |
 | <a name="input_required_resource_access_list"></a> [required\_resource\_access\_list](#input\_required\_resource\_access\_list) | A map of resource\_app\_ids with their access configurations. | <pre>map(list(object({<br/>    id   = string<br/>    type = string<br/>  })))</pre> | <pre>{<br/>  "00000003-0000-0000-c000-000000000000": [<br/>    {<br/>      "id": "14dad69e-099b-42c9-810b-d002981feec1",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "37f7f235-527c-4136-accd-4a02d197296e",<br/>      "type": "Scope"<br/>    },<br/>    {<br/>      "id": "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",<br/>      "type": "Scope"<br/>    }<br/>  ]<br/>}</pre> | no |
+| <a name="input_role_assignments_required"></a> [role\_assignments\_required](#input\_role\_assignments\_required) | Whether role assignments are required to be able to use the app. Least privilege principle encourages true. | `bool` | `true` | no |
+| <a name="input_system_support_object_ids"></a> [system\_support\_object\_ids](#input\_system\_support\_object\_ids) | The object ids of the user/groups that should be able to support the system or core of the platform. Roles trickle down so this role includes application support. | `list(string)` | `[]` | no |
 
 ## Outputs
 
 No outputs.
 <!-- END_TF_DOCS -->
+
+## Compatibility
+
+| Module Version | Compatibility |
+|---|---|
+| `> 2.1.0` | `unique.ai`: `~> 2025.16` |
+
+## Upgrading
+
+### ~> `3.0.0`
+
+> [!CAUTION]
+> Make sure to transition through 3.0.0 in order to not break your applications introducing a chicken-egg problem. Do not skip `3.0.0`.
+
+Version `3.0.0` introduces significant changes to how application roles and permissions are managed, shifting from a single `maintainers` role to a more granular, hierarchical system. It also introduces stricter defaults for role assignments.
+
+#### Role System Change
+
+*   The `maintainers_principal_object_ids` input variable has been **removed**.
+*   Three new input variables have been introduced to define access based on support tiers:
+    *   `application_support_object_ids`: For users/groups providing direct application support.
+    *   `system_support_object_ids`: For users/groups supporting the underlying system/platform. This tier implicitly includes Application Support permissions.
+    *   `infrastructure_support_object_ids`: For users/groups supporting the infrastructure. This tier implicitly includes both System and Application Support permissions.
+*   **Action Required:** Replace the usage of `maintainers_principal_object_ids` with the appropriate new variable(s) based on the level of access required. For example, if the previous maintainers only needed application-level access, use `application_support_object_ids`.
+
+    ```diff
+    module "my_app_registration" {
+      source = "github.com/Unique-AG/terraform-modules.git//modules/azure-entra-app-registration?ref=azure-entra-app-registration-3.0.0"
+
+      display_name = "My Application"
+    - maintainers_principal_object_ids = ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"]
+    + application_support_object_ids = ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"]
+    + # Optionally add system_support_object_ids = [...]
+    + # Optionally add infrastructure_support_object_ids = [...]
+
+      # ... other variables
+    }
+    ```
+
+#### Backward Compatibility
+
+*   To ease the transition and avoid breaking existing Single Sign-On (SSO) configurations relying on the old `maintain` app role, this role still exists in `3.0.0`.
+*   Assignments for this legacy `maintain` role are now automatically created based on the `application_support_object_ids` variable.
+*   **Warning:** This legacy `maintain` role and its associated resources will be **removed in version `4.0.0`**. Update your relying applications to use the new roles (`application_support`, `system_support`, `infrastructure_support`) before upgrading to `4.0.0`.
+
+#### Role Assignment Requirement
+
+*   A new boolean variable `role_assignments_required` has been added. It defaults to `true`.
+*   When `true`, users must be assigned one of the defined app roles (`application_support`, `system_support`, or `infrastructure_support`) to successfully sign in to the application. This enforces the principle of least privilege.
+*   **Action Required:** If your application does *not* require users to have specific roles assigned for login, explicitly set `role_assignments_required = false`.
+
+#### Minor Changes
+
+*   Internal URLs for privacy statements and terms of service have been updated from `unique.ch` to `unique.ai`. This typically requires no action.
+
+Please review your module configurations and update them according to these changes when upgrading to `v3.0.0`.
+

--- a/modules/azure-entra-app-registration/README.md
+++ b/modules/azure-entra-app-registration/README.md
@@ -25,10 +25,10 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuread_app_role_assignment.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
-| [azuread_app_role_assignment.standard](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
+| [azuread_app_role_assignment.managed_roles](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_application_app_role.maintainers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
-| [azuread_application_app_role.standard](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
+| [azuread_application_app_role.managed_roles](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_app_role) | resource |
 | [azuread_application_password.aad_app_password](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
 | [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azurerm_key_vault_secret.aad_app_gitops_client_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |

--- a/modules/azure-entra-app-registration/aad-app.tf
+++ b/modules/azure-entra-app-registration/aad-app.tf
@@ -1,13 +1,13 @@
 resource "azuread_application" "this" {
   display_name          = var.display_name
-  sign_in_audience      = "AzureADMyOrg"
-  privacy_statement_url = "https://www.unique.ai/privacy"
-  terms_of_service_url  = "https://www.unique.ai/terms"
+  sign_in_audience      = var.sign_in_audience
+  privacy_statement_url = var.privacy_statement_url
+  terms_of_service_url  = var.terms_of_service_url
 
   owners = var.owner_user_object_ids
 
   web {
-    homepage_url = "https://www.unique.ai"
+    homepage_url = var.homepage_url
     implicit_grant {
       access_token_issuance_enabled = true
       id_token_issuance_enabled     = true

--- a/modules/azure-entra-app-registration/aad-app.tf
+++ b/modules/azure-entra-app-registration/aad-app.tf
@@ -1,13 +1,13 @@
 resource "azuread_application" "this" {
   display_name          = var.display_name
   sign_in_audience      = "AzureADMyOrg"
-  privacy_statement_url = "https://www.unique.ch/privacy"
-  terms_of_service_url  = "https://www.unique.ch/terms"
+  privacy_statement_url = "https://www.unique.ai/privacy"
+  terms_of_service_url  = "https://www.unique.ai/terms"
 
   owners = var.owner_user_object_ids
 
   web {
-    homepage_url = "https://www.unique.ch"
+    homepage_url = "https://www.unique.ai"
     implicit_grant {
       access_token_issuance_enabled = true
       id_token_issuance_enabled     = true

--- a/modules/azure-entra-app-registration/app-role.tf
+++ b/modules/azure-entra-app-registration/app-role.tf
@@ -5,7 +5,7 @@ locals {
   app_support_users    = setunion(var.application_support_object_ids, local.system_support_users)
   all_users            = setunion(var.user_object_ids, local.app_support_users)
 
-  # Define standard app roles attributes
+  # Define app roles attributes
   app_roles_map = {
     # the UUIDs are manually created via a tool like https://www.uuidgenerator.net/version4
     # reason: the loop is way easier to control and read this way than to use random_uuid
@@ -59,8 +59,8 @@ resource "azuread_service_principal" "this" {
   app_role_assignment_required = var.role_assignments_required
 }
 
-# Create standard app roles using for_each
-resource "azuread_application_app_role" "standard" {
+# Create app roles using for_each
+resource "azuread_application_app_role" "managed_roles" {
   for_each       = local.app_roles_map
   application_id = azuread_application.this.id
   role_id        = each.value.role_id
@@ -71,12 +71,12 @@ resource "azuread_application_app_role" "standard" {
   value                = each.value.value
 }
 
-# Create standard app role assignments using for_each
-resource "azuread_app_role_assignment" "standard" {
+# Create app role assignments using for_each
+resource "azuread_app_role_assignment" "managed_roles" {
   # Create a unique key for each role-principal pair
   for_each = { for assignment in local.flattened_assignments : "${assignment.role_name}:${assignment.principal_id}" => assignment }
 
-  app_role_id         = azuread_application_app_role.standard[each.value.role_name].role_id
+  app_role_id         = azuread_application_app_role.managed_roles[each.value.role_name].role_id
   principal_object_id = each.value.principal_id
   resource_object_id  = azuread_service_principal.this.object_id
 }

--- a/modules/azure-entra-app-registration/app-role.tf
+++ b/modules/azure-entra-app-registration/app-role.tf
@@ -1,5 +1,66 @@
 resource "random_uuid" "maintainers" {}
+resource "random_uuid" "application_support" {}
+resource "random_uuid" "system_support" {}
+resource "random_uuid" "infrastructure_support" {}
 
+resource "azuread_service_principal" "this" {
+  client_id                    = azuread_application.this.client_id
+  app_role_assignment_required = var.role_assignments_required
+}
+
+resource "azuread_application_app_role" "application_support" {
+  application_id = azuread_application.this.id
+  role_id        = random_uuid.application_support.id
+
+  allowed_member_types = ["User"]
+  description          = "Application Support, allows to support the application."
+  display_name         = "Application Support"
+  value                = "application_support"
+}
+
+resource "azuread_app_role_assignment" "application_support" {
+  for_each            = setunion(var.application_support_object_ids, var.system_support_object_ids, var.infrastructure_support_object_ids)
+  app_role_id         = azuread_application_app_role.application_support.role_id
+  principal_object_id = each.value
+  resource_object_id  = azuread_service_principal.this.object_id
+}
+
+resource "azuread_application_app_role" "system_support" {
+  application_id = azuread_application.this.id
+  role_id        = random_uuid.system_support.id
+
+  allowed_member_types = ["User"]
+  description          = "System Support, allows to support the system around the application."
+  display_name         = "System Support"
+  value                = "system_support"
+}
+
+resource "azuread_app_role_assignment" "system_support" {
+  for_each            = setunion(var.system_support_object_ids, var.infrastructure_support_object_ids)
+  app_role_id         = azuread_application_app_role.system_support.role_id
+  principal_object_id = each.value
+  resource_object_id  = azuread_service_principal.this.object_id
+}
+
+resource "azuread_application_app_role" "infrastructure_support" {
+  application_id = azuread_application.this.id
+  role_id        = random_uuid.infrastructure_support.id
+
+  allowed_member_types = ["User"]
+  description          = "Infrastructure Support, allows to support the infrastructure of the application."
+  display_name         = "Infrastructure Support"
+  value                = "infrastructure_support"
+}
+
+resource "azuread_app_role_assignment" "infrastructure_support" {
+  for_each            = toset(var.infrastructure_support_object_ids)
+  app_role_id         = azuread_application_app_role.infrastructure_support.role_id
+  principal_object_id = each.value
+  resource_object_id  = azuread_service_principal.this.object_id
+}
+
+# Legacy support to not break existing SSO configurations on transition, see README.md
+# support for this will be removed in 4.0.0
 resource "azuread_application_app_role" "maintainers" {
   application_id = azuread_application.this.id
   role_id        = random_uuid.maintainers.id
@@ -10,12 +71,8 @@ resource "azuread_application_app_role" "maintainers" {
   value                = "maintain"
 }
 
-resource "azuread_service_principal" "this" {
-  client_id = azuread_application.this.client_id
-}
-
 resource "azuread_app_role_assignment" "maintainers" {
-  for_each            = toset(var.maintainers_principal_object_ids)
+  for_each            = toset(var.application_support_object_ids)
   app_role_id         = azuread_application_app_role.maintainers.role_id
   principal_object_id = each.value
   resource_object_id  = azuread_service_principal.this.object_id

--- a/modules/azure-entra-app-registration/app-role.tf
+++ b/modules/azure-entra-app-registration/app-role.tf
@@ -1,84 +1,90 @@
-resource "random_uuid" "maintainers" {}
-resource "random_uuid" "user" {}
-resource "random_uuid" "application_support" {}
-resource "random_uuid" "system_support" {}
-resource "random_uuid" "infrastructure_support" {}
+locals {
+  # Define cumulative sets for easier role assignment
+  infra_support_users  = toset(var.infrastructure_support_object_ids)
+  system_support_users = setunion(var.system_support_object_ids, local.infra_support_users)
+  app_support_users    = setunion(var.application_support_object_ids, local.system_support_users)
+  all_users            = setunion(var.user_object_ids, local.app_support_users)
+
+  # Define standard app roles attributes
+  app_roles_map = {
+    # the UUIDs are manually created via a tool like https://www.uuidgenerator.net/version4
+    # reason: the loop is way easier to control and read this way than to use random_uuid
+    user = {
+      role_id      = "6a902661-cfac-44f4-846c-bc5ceaa012d4"
+      description  = "User, allows to use the application or login without any additional permissions."
+      display_name = "User"
+      value        = "user"
+    }
+    application_support = {
+      role_id      = "719570d9-6707-40f4-9193-29ae0745392e"
+      description  = "Application Support, allows to support the application."
+      display_name = "Application Support"
+      value        = "application_support"
+    }
+    system_support = {
+      role_id      = "8719acef-9791-41e4-9621-92d05315181c"
+      description  = "System Support, allows to support the system around the application."
+      display_name = "System Support"
+      value        = "system_support"
+    }
+    infrastructure_support = {
+      role_id      = "0a7f4e66-4942-4a2e-a433-82e54464f116"
+      description  = "Infrastructure Support, allows to support the infrastructure of the application."
+      display_name = "Infrastructure Support"
+      value        = "infrastructure_support"
+    }
+  }
+
+  # Map roles to their corresponding principal sets
+  role_assignment_sets = {
+    user                   = local.all_users
+    application_support    = local.app_support_users
+    system_support         = local.system_support_users
+    infrastructure_support = local.infra_support_users
+  }
+
+  # Flatten the assignments for use in for_each
+  flattened_assignments = flatten([
+    for role_name, principal_ids in local.role_assignment_sets : [
+      for principal_id in principal_ids : {
+        role_name    = role_name
+        principal_id = principal_id
+      }
+    ]
+  ])
+}
 
 resource "azuread_service_principal" "this" {
   client_id                    = azuread_application.this.client_id
   app_role_assignment_required = var.role_assignments_required
 }
 
-resource "azuread_application_app_role" "user" {
+# Create standard app roles using for_each
+resource "azuread_application_app_role" "standard" {
+  for_each       = local.app_roles_map
   application_id = azuread_application.this.id
-  role_id        = random_uuid.user.id
+  role_id        = each.value.role_id
 
   allowed_member_types = ["User"]
-  description          = "User, allows to use the application or login without any additional permissions."
-  display_name         = "User"
-  value                = "user"
+  description          = each.value.description
+  display_name         = each.value.display_name
+  value                = each.value.value
 }
 
-resource "azuread_app_role_assignment" "user" {
-  for_each            = setunion(var.user_object_ids, var.application_support_object_ids, var.system_support_object_ids, var.infrastructure_support_object_ids)
-  app_role_id         = azuread_application_app_role.user.role_id
-  principal_object_id = each.value
+# Create standard app role assignments using for_each
+resource "azuread_app_role_assignment" "standard" {
+  # Create a unique key for each role-principal pair
+  for_each = { for assignment in local.flattened_assignments : "${assignment.role_name}:${assignment.principal_id}" => assignment }
+
+  app_role_id         = azuread_application_app_role.standard[each.value.role_name].role_id
+  principal_object_id = each.value.principal_id
   resource_object_id  = azuread_service_principal.this.object_id
 }
 
-resource "azuread_application_app_role" "application_support" {
-  application_id = azuread_application.this.id
-  role_id        = random_uuid.application_support.id
-
-  allowed_member_types = ["User"]
-  description          = "Application Support, allows to support the application."
-  display_name         = "Application Support"
-  value                = "application_support"
-}
-
-resource "azuread_app_role_assignment" "application_support" {
-  for_each            = setunion(var.application_support_object_ids, var.system_support_object_ids, var.infrastructure_support_object_ids)
-  app_role_id         = azuread_application_app_role.application_support.role_id
-  principal_object_id = each.value
-  resource_object_id  = azuread_service_principal.this.object_id
-}
-
-resource "azuread_application_app_role" "system_support" {
-  application_id = azuread_application.this.id
-  role_id        = random_uuid.system_support.id
-
-  allowed_member_types = ["User"]
-  description          = "System Support, allows to support the system around the application."
-  display_name         = "System Support"
-  value                = "system_support"
-}
-
-resource "azuread_app_role_assignment" "system_support" {
-  for_each            = setunion(var.system_support_object_ids, var.infrastructure_support_object_ids)
-  app_role_id         = azuread_application_app_role.system_support.role_id
-  principal_object_id = each.value
-  resource_object_id  = azuread_service_principal.this.object_id
-}
-
-resource "azuread_application_app_role" "infrastructure_support" {
-  application_id = azuread_application.this.id
-  role_id        = random_uuid.infrastructure_support.id
-
-  allowed_member_types = ["User"]
-  description          = "Infrastructure Support, allows to support the infrastructure of the application."
-  display_name         = "Infrastructure Support"
-  value                = "infrastructure_support"
-}
-
-resource "azuread_app_role_assignment" "infrastructure_support" {
-  for_each            = toset(var.infrastructure_support_object_ids)
-  app_role_id         = azuread_application_app_role.infrastructure_support.role_id
-  principal_object_id = each.value
-  resource_object_id  = azuread_service_principal.this.object_id
-}
-
+# ------------------------------------------------------------------------------------
 # Legacy support to not break existing SSO configurations on transition, see README.md
 # support for this will be removed in 4.0.0
+resource "random_uuid" "maintainers" {}
 resource "azuread_application_app_role" "maintainers" {
   application_id = azuread_application.this.id
   role_id        = random_uuid.maintainers.id
@@ -88,9 +94,8 @@ resource "azuread_application_app_role" "maintainers" {
   display_name         = "Maintain"
   value                = "maintain"
 }
-
 resource "azuread_app_role_assignment" "maintainers" {
-  for_each            = toset(var.application_support_object_ids)
+  for_each            = toset(var.application_support_object_ids) # Keep legacy assignment logic
   app_role_id         = azuread_application_app_role.maintainers.role_id
   principal_object_id = each.value
   resource_object_id  = azuread_service_principal.this.object_id

--- a/modules/azure-entra-app-registration/examples/simple/main.tf
+++ b/modules/azure-entra-app-registration/examples/simple/main.tf
@@ -9,6 +9,6 @@ module "entra_app" {
   client_secret_generation_config = {
     enabled = false
   }
-  display_name                     = "example-app"
-  maintainers_principal_object_ids = ["00000000-0000-0000-0000-000000000000"]
+  display_name                   = "example-app"
+  application_support_object_ids = ["00000000-0000-0000-0000-000000000001"]
 }

--- a/modules/azure-entra-app-registration/examples/simple/main.tf
+++ b/modules/azure-entra-app-registration/examples/simple/main.tf
@@ -10,5 +10,6 @@ module "entra_app" {
     enabled = false
   }
   display_name                   = "example-app"
+  user_object_ids                = ["00000000-0000-0000-0000-000000000002"]
   application_support_object_ids = ["00000000-0000-0000-0000-000000000001"]
 }

--- a/modules/azure-entra-app-registration/module.yaml
+++ b/modules/azure-entra-app-registration/module.yaml
@@ -9,7 +9,7 @@ changes:
   - kind: changed
     description: "Updated URLs (`privacy_statement_url`, `terms_of_service_url`, `homepage_url`) from unique.ch to unique.ai."
   - kind: added
-    description: "⚠️ Introduced granular, hierarchical support roles: `application_support`, `system_support`, and `infrastructure_support` with corresponding input variables."
+    description: "⚠️ Introduced granular, hierarchical support roles: `user`, `application_support`, `system_support`, and `infrastructure_support` with corresponding input variables."
   - kind: added
     description: "⚠️ Added `role_assignments_required` variable to control if app role assignment is mandatory for usage (defaults to true)."
   - kind: changed

--- a/modules/azure-entra-app-registration/module.yaml
+++ b/modules/azure-entra-app-registration/module.yaml
@@ -1,7 +1,16 @@
 name: azure-entra-app-registration
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-entra-app-registration
-version: 2.0.0
+version: 3.0.0
+# 4.0.0 must remove maintainer role
+compatibility:
+  unique.ai: ~> 2025.16
 changes:
   - kind: changed
-    description: "Client secret generation is now optional in cases where Key Vault output is not needed or desired."
+    description: "Updated URLs (`privacy_statement_url`, `terms_of_service_url`, `homepage_url`) from unique.ch to unique.ai."
+  - kind: added
+    description: "⚠️ Introduced granular, hierarchical support roles: `application_support`, `system_support`, and `infrastructure_support` with corresponding input variables."
+  - kind: added
+    description: "⚠️ Added `role_assignments_required` variable to control if app role assignment is mandatory for usage (defaults to true)."
+  - kind: changed
+    description: "Deprecated the `maintainers` role and `maintainers_principal_object_ids` variable in favor of the new role system. The legacy role is temporarily mapped to `application_support` assignments for backward compatibility. This will be removed in 4.0.0."

--- a/modules/azure-entra-app-registration/variables.tf
+++ b/modules/azure-entra-app-registration/variables.tf
@@ -1,6 +1,6 @@
 variable "display_name" {
   type        = string
-  description = "The displayed name in Entra"
+  description = "The displayed name in Entra ID."
 }
 
 variable "client_secret_generation_config" {
@@ -65,7 +65,26 @@ variable "required_resource_access_list" {
   }
 }
 
-variable "maintainers_principal_object_ids" {
+variable "application_support_object_ids" {
   type        = list(string)
-  description = "The object ids of the user/groups/service_principal "
+  description = "The object ids of the user/groups that should be able to support the application."
+  default     = []
+}
+
+variable "system_support_object_ids" {
+  type        = list(string)
+  description = "The object ids of the user/groups that should be able to support the system or core of the platform. Roles trickle down so this role includes application support."
+  default     = []
+}
+
+variable "infrastructure_support_object_ids" {
+  type        = list(string)
+  description = "The object ids of the user/groups that should be able to support the infrastructure of the platform. Roles trickle down so this role includes both system and application support."
+  default     = []
+}
+
+variable "role_assignments_required" {
+  type        = bool
+  description = "Whether role assignments are required to be able to use the app. Least privilege principle encourages true."
+  default     = true
 }

--- a/modules/azure-entra-app-registration/variables.tf
+++ b/modules/azure-entra-app-registration/variables.tf
@@ -65,6 +65,12 @@ variable "required_resource_access_list" {
   }
 }
 
+variable "user_object_ids" {
+  type        = list(string)
+  description = "The object ids of the user/groups that should be able to just use the application/login."
+  default     = []
+}
+
 variable "application_support_object_ids" {
   type        = list(string)
   description = "The object ids of the user/groups that should be able to support the application."

--- a/modules/azure-entra-app-registration/variables.tf
+++ b/modules/azure-entra-app-registration/variables.tf
@@ -67,7 +67,7 @@ variable "required_resource_access_list" {
 
 variable "user_object_ids" {
   type        = list(string)
-  description = "The object ids of the user/groups that should be able to just use the application/login."
+  description = "The object ids of the user/groups that should be able to just use the application/login. All support profiles will be added to this list."
   default     = []
 }
 
@@ -94,3 +94,28 @@ variable "role_assignments_required" {
   description = "Whether role assignments are required to be able to use the app. Least privilege principle encourages true."
   default     = true
 }
+
+variable "sign_in_audience" {
+  type        = string
+  description = "The audience of the app."
+  default     = "AzureADMyOrg"
+}
+
+variable "privacy_statement_url" {
+  type        = string
+  description = "The privacy statement url of the app."
+  default     = "https://www.unique.ai/privacy"
+}
+
+variable "terms_of_service_url" {
+  type        = string
+  description = "The terms of service url of the app."
+  default     = "https://www.unique.ai/terms"
+}
+
+variable "homepage_url" {
+  type        = string
+  description = "The homepage url of the app."
+  default     = "https://www.unique.ai"
+}
+


### PR DESCRIPTION
> [!CAUTION]
> Make sure to transition through 3.0.0 in order to not break your applications introducing a chicken-egg problem. Do not skip `3.0.0`.

Version `3.0.0` introduces significant changes to how application roles and permissions are managed, shifting from a single `maintainers` role to a more granular, hierarchical system. It also introduces stricter defaults for role assignments.

#### Role System Change

*   The `maintainers_principal_object_ids` input variable has been **removed**.
*   Three new input variables have been introduced to define access based on support tiers:
    *   `application_support_object_ids`: For users/groups providing direct application support.
    *   `system_support_object_ids`: For users/groups supporting the underlying system/platform. This tier implicitly includes Application Support permissions.
    *   `infrastructure_support_object_ids`: For users/groups supporting the infrastructure. This tier implicitly includes both System and Application Support permissions.
*   **Action Required:** Replace the usage of `maintainers_principal_object_ids` with the appropriate new variable(s) based on the level of access required. For example, if the previous maintainers only needed application-level access, use `application_support_object_ids`.

    ```diff
    module "my_app_registration" {
      source = "github.com/Unique-AG/terraform-modules.git//modules/azure-entra-app-registration?ref=azure-entra-app-registration-3.0.0"

      display_name = "My Application"
    - maintainers_principal_object_ids = ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"]
    + user_object_ids                = ["00000000-0000-0000-0000-000000000002"]
    + application_support_object_ids = ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"]
    + # Optionally add system_support_object_ids = [...]
    + # Optionally add infrastructure_support_object_ids = [...]

      # ... other variables
    }
    ```

#### Backward Compatibility

*   To ease the transition and avoid breaking existing Single Sign-On (SSO) configurations relying on the old `maintain` app role, this role still exists in `3.0.0`.
*   Assignments for this legacy `maintain` role are now automatically created based on the `application_support_object_ids` variable.
*   **Warning:** This legacy `maintain` role and its associated resources will be **removed in version `4.0.0`**. Update your relying applications to use the new roles (`application_support`, `system_support`, `infrastructure_support`) before upgrading to `4.0.0`.

#### Role Assignment Requirement

*   A new boolean variable `role_assignments_required` has been added. It defaults to `true`.
*   When `true`, users must be assigned one of the defined app roles (`application_support`, `system_support`, or `infrastructure_support`) to successfully sign in to the application. This enforces the principle of least privilege.
*   If you'd like users to just be able to login, use `user_object_ids`.
*   **Action Required:** If your application does *not* require users to have specific roles assigned for login, explicitly set `role_assignments_required = false`.

#### Minor Changes

*   Internal URLs for privacy statements and terms of service have been updated from `unique.ch` to `unique.ai`. This typically requires no action.

Please review your module configurations and update them according to these changes when upgrading to `v3.0.0`.
