### PR TITLE
feat(unique-secrets-bundle): fix content_type drift

### DIFF
--- a/modules/azure-unique-secrets-bundle/module.yaml
+++ b/modules/azure-unique-secrets-bundle/module.yaml
@@ -1,9 +1,9 @@
 name: azure-unique-secrets-bundle
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-unique-secrets-bundle
-version: 1.0.0
+version: 1.0.1
 compatibility:
   unique.ai: ~> 2025.16
 changes:
-  - kind: added
-    description: "Secrets bundle for Azure."
+  - kind: fixed
+    description: "content_type of manual secrets is now ignored."

--- a/modules/azure-unique-secrets-bundle/secrets.tf
+++ b/modules/azure-unique-secrets-bundle/secrets.tf
@@ -10,6 +10,6 @@ resource "azurerm_key_vault_secret" "manual_secret" {
   expiration_date = lookup(each.value, "expiration_date", "2099-12-31T23:59:59Z")
   content_type    = lookup(each.value, "content_type", "text/plain")
   lifecycle {
-    ignore_changes = [value, tags]
+    ignore_changes = [value, tags, content_type]
   }
 }


### PR DESCRIPTION
## Describe your changes

fixes

```
  # module.secrets_bundle.azurerm_key_vault_secret.manual_secret["xxx"] will be updated in-place
  ~ resource "azurerm_key_vault_secret" "manual_secret" {
      + content_type            = "text/plain"
        id                      = "https://vault"
        name                    = "xxx"
        tags                    = {}
        # (8 unchanged attributes hidden)
    }

…
```

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
