### PR TITLE
feat(azure-postgresql): add flex_storage_auto_grow_enabled 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mkdocs
 *.tfstate
 *.tfstate.backup
 modules/azure-speech-service/examples/simple/providers.tf
+*providers.tf

--- a/modules/azure-postgresql/README.md
+++ b/modules/azure-postgresql/README.md
@@ -57,7 +57,8 @@ No modules.
 | <a name="input_flex_pg_backup_retention_days"></a> [flex\_pg\_backup\_retention\_days](#input\_flex\_pg\_backup\_retention\_days) | The number of days to retain backups for the PostgreSQL server. | `number` | `7` | no |
 | <a name="input_flex_pg_version"></a> [flex\_pg\_version](#input\_flex\_pg\_version) | The version of the PostgreSQL server. | `string` | `"14"` | no |
 | <a name="input_flex_sku"></a> [flex\_sku](#input\_flex\_sku) | The SKU for the PostgreSQL server. | `string` | `"GP_Standard_D2ds_v5"` | no |
-| <a name="input_flex_storage_mb"></a> [flex\_storage\_mb](#input\_flex\_storage\_mb) | The storage size in MB for the PostgreSQL server. | `number` | `32768` | no |
+| <a name="input_flex_storage_auto_grow_enabled"></a> [flex\_storage\_auto\_grow\_enabled](#input\_flex\_storage\_auto\_grow\_enabled) | Specifies whether the storage auto grow is enabled for the PostgreSQL Flexible Server | `bool` | `false` | no |
+| <a name="input_flex_storage_mb"></a> [flex\_storage\_mb](#input\_flex\_storage\_mb) | The storage size in MB for the PostgreSQL server. | `number` | `131072` | no |
 | <a name="input_host_secret_name"></a> [host\_secret\_name](#input\_host\_secret\_name) | Name of the secret containing the host | `string` | `null` | no |
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | List of managed identity IDs to assign to the storage account. | `list(string)` | `[]` | no |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | The ID of the Key Vault where the secrets will be stored | `string` | `null` | no |

--- a/modules/azure-postgresql/examples/simple/main.tf
+++ b/modules/azure-postgresql/examples/simple/main.tf
@@ -56,11 +56,17 @@ resource "random_password" "postgres_password" {
   special = false
 }
 
+resource "random_string" "server_name" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
 module "apfs" {
   source              = "../.."
   admin_password      = random_password.postgres_password.result
   administrator_login = random_password.postgres_username.result
-  name                = "my-postgresql-server"
+  name                = "my-postgresql-server-${random_string.server_name.result}"
   resource_group_name = azurerm_resource_group.example.name
   location            = "switzerlandnorth"
   tags = {

--- a/modules/azure-postgresql/main.tf
+++ b/modules/azure-postgresql/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_postgresql_flexible_server" "apfs" {
   storage_mb             = var.flex_storage_mb
   tags                   = var.tags
   zone                   = var.zone
+  auto_grow_enabled      = var.flex_storage_auto_grow_enabled
 
   public_network_access_enabled = var.public_network_access_enabled
   backup_retention_days         = var.flex_pg_backup_retention_days

--- a/modules/azure-postgresql/module.yaml
+++ b/modules/azure-postgresql/module.yaml
@@ -2,10 +2,8 @@
 name: azure-postgresql
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-postgresql
-version: 2.0.0-rc.2
+version: 2.0.0
 changes:
-  - kind: changed
-    description: "Require Terraform >= 1.5, azurerm ~> 4.15. Do not require hashicorp/random anymore, since it used only for the example usage"
-
-
+   - kind: added
+     description: "Add `flex_storage_auto_grow_enabled` variable"
     

--- a/modules/azure-postgresql/module.yaml
+++ b/modules/azure-postgresql/module.yaml
@@ -3,6 +3,8 @@ name: azure-postgresql
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-postgresql
 version: 2.0.0
+compatibility:
+  unique.ai: ~> 2025.16
 changes:
    - kind: added
      description: "Add `flex_storage_auto_grow_enabled` variable"

--- a/modules/azure-postgresql/variables.tf
+++ b/modules/azure-postgresql/variables.tf
@@ -48,7 +48,7 @@ variable "flex_sku" {
 variable "flex_storage_mb" {
   description = "The storage size in MB for the PostgreSQL server."
   type        = number
-  default     = 32768
+  default     = 131072
   validation {
     condition     = var.flex_storage_mb > 0
     error_message = "Storage size must be greater than 0."
@@ -212,4 +212,10 @@ variable "database_connection_string_secret_prefix" {
   description = "Prefix of the secret containing the full connection string. The full name of the secret is this prefix + database name"
   default     = "database-url-"
   type        = string
+}
+
+variable "flex_storage_auto_grow_enabled" {
+  description = "Specifies whether the storage auto grow is enabled for the PostgreSQL Flexible Server"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
- Added `flex_storage_auto_grow_enabled` variable to control automatic storage growth for PostgreSQL Flexible Server.
- Updated default storage size to 131072 MB.
- Revised README to include new variable documentation.
- Bumped module version to 2.0.0 in `module.yaml`.

## Describe your changes

<!-- Describe your changes in detail -->

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
