### PR TITLE
fix(speech): deprecation warning

### DIFF
--- a/modules/azure-speech-service/main.tf
+++ b/modules/azure-speech-service/main.tf
@@ -51,7 +51,7 @@ resource "azurerm_monitor_diagnostic_setting" "diag" {
     }
   }
 
-  dynamic "metric" {
+  dynamic "enabled_metric" {
     for_each = try(
       each.value.diagnostic_settings != null ?
       (each.value.diagnostic_settings.enabled_metrics != null ?
@@ -61,8 +61,7 @@ resource "azurerm_monitor_diagnostic_setting" "diag" {
       []
     )
     content {
-      category = metric.value
-      enabled  = each.value.diagnostic_settings.enabled_metrics != null
+      category = enabled_metric.value
     }
   }
 

--- a/modules/azure-speech-service/module.yaml
+++ b/modules/azure-speech-service/module.yaml
@@ -1,9 +1,9 @@
 name: azure-speech-service
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-speech-service
-version:  4.0.0
+version: 4.0.1
 compatibility:
   unique.ai: ~> 2025.26
 changes:
   - kind: fixed
-    description: "Modified output for the Cognitive Services Accounts to include the whole resource not just the ID"
+    description: "metric has been deprecated in favor of the enabled_metric"


### PR DESCRIPTION
## Describe your changes

fixes

```
│ Warning: Argument is deprecated
│ 
│   with module.speech_service.azurerm_monitor_diagnostic_setting.diag["switzerlandnorth-speech"],
│   on .terraform/modules/speech_service/modules/azure-speech-service/main.tf line 41, in resource "azurerm_monitor_diagnostic_setting" "diag":
│   41: resource "azurerm_monitor_diagnostic_setting" "diag" {
│ 
│ `metric` has been deprecated in favor of the `enabled_metric` property and
│ will be removed in v5.0 of the AzureRM provider
│ 
│ (and 39 more similar warnings elsewhere)
```

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
