### PR TITLE
fix(azure-storage-account): correct change feed retention days

### DIFF
--- a/modules/azure-storage-account/main.tf
+++ b/modules/azure-storage-account/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_storage_account" "storage_account" {
   # enable access from browsers
   blob_properties {
     change_feed_enabled           = var.data_protection_settings.change_feed_retention_days > 0
-    change_feed_retention_in_days = var.data_protection_settings.change_feed_retention_days > 0 ? var.data_protection_settings.change_feed_retention_days : null
+    change_feed_retention_in_days = var.data_protection_settings.change_feed_retention_days > 0 ? var.data_protection_settings.change_feed_retention_days : -1
     versioning_enabled            = var.data_protection_settings.versioning_enabled
     dynamic "cors_rule" {
       for_each = var.cors_rules

--- a/modules/azure-storage-account/module.yaml
+++ b/modules/azure-storage-account/module.yaml
@@ -1,9 +1,10 @@
 name: azure-storage-account
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-storage-account
-version: 3.0.2
+version: 3.0.3
 compatibility:
   unique.ai: ~> 2025.24
 changes:
-  - kind: changed
-    description: "Default value for shared_access_key_enabled is now true."
+  - kind: fixed
+    description: "In previous version, the change feed retention days was not set correctly. 
+    Leading to the change feed being enabled. This has been fixed."


### PR DESCRIPTION
Updated the default value for change_feed_retention_in_days to -1 to prevent unintended enabling of change feed when retention days are not set. Bumped module version to 3.0.3 and updated changelog accordingly.


## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
