### PR TITLE
fix(openai): reference key by key not name

### DIFF
--- a/.github/workflows/azure-application-gateway.yaml
+++ b/.github/workflows/azure-application-gateway.yaml
@@ -1,0 +1,26 @@
+name: "Release Azure Application Gateway"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-application-gateway/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-application-gateway/**
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-application-gateway
+  release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-application-gateway

--- a/.github/workflows/azure-bing-search.yaml
+++ b/.github/workflows/azure-bing-search.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-bing-search/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-bing-search/**
 
 jobs:
   validate:
@@ -15,6 +20,7 @@ jobs:
     with:
       module: azure-bing-search
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-bing-search

--- a/.github/workflows/azure-bing-search.yaml
+++ b/.github/workflows/azure-bing-search.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Bing Search"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-bing-search/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-bing-search
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-bing-search

--- a/.github/workflows/azure-defender.yaml
+++ b/.github/workflows/azure-defender.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-defender/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-defender/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-defender.yaml
+++ b/.github/workflows/azure-defender.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-defender
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-defender

--- a/.github/workflows/azure-defender.yaml
+++ b/.github/workflows/azure-defender.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Defender"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-defender/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-defender
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-defender

--- a/.github/workflows/azure-document-intelligence.yaml
+++ b/.github/workflows/azure-document-intelligence.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Document Intelligence"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-document-intelligence/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-document-intelligence
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-document-intelligence

--- a/.github/workflows/azure-document-intelligence.yaml
+++ b/.github/workflows/azure-document-intelligence.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-document-intelligence/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-document-intelligence/**
 
 jobs:
   validate:
@@ -15,6 +20,7 @@ jobs:
     with:
       module: azure-document-intelligence
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-document-intelligence

--- a/.github/workflows/azure-entra-app-registration.yaml
+++ b/.github/workflows/azure-entra-app-registration.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-entra-app-registration/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-entra-app-registration/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-entra-app-registration.yaml
+++ b/.github/workflows/azure-entra-app-registration.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Entra App Registration"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-entra-app-registration/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-entra-app-registration
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-entra-app-registration

--- a/.github/workflows/azure-entra-app-registration.yaml
+++ b/.github/workflows/azure-entra-app-registration.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-entra-app-registration
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-entra-app-registration

--- a/.github/workflows/azure-kubernetes-service.yaml
+++ b/.github/workflows/azure-kubernetes-service.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-kubernetes-service
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-kubernetes-service

--- a/.github/workflows/azure-kubernetes-service.yaml
+++ b/.github/workflows/azure-kubernetes-service.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Kubernetes Service"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-kubernetes-service/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-kubernetes-service
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-kubernetes-service

--- a/.github/workflows/azure-kubernetes-service.yaml
+++ b/.github/workflows/azure-kubernetes-service.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-kubernetes-service/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-kubernetes-service/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-openai.yaml
+++ b/.github/workflows/azure-openai.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-openai
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-openai

--- a/.github/workflows/azure-openai.yaml
+++ b/.github/workflows/azure-openai.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-openai/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-openai/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-openai.yaml
+++ b/.github/workflows/azure-openai.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure OpenAI"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-openai/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-openai
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-openai

--- a/.github/workflows/azure-postgresql.yaml
+++ b/.github/workflows/azure-postgresql.yaml
@@ -7,8 +7,18 @@ on:
       - main
     paths:
       - modules/azure-postgresql/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-postgresql/**
 
 jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-postgresql
   release:
     uses: ./.github/workflows/release.yaml
     with:

--- a/.github/workflows/azure-postgresql.yaml
+++ b/.github/workflows/azure-postgresql.yaml
@@ -1,0 +1,15 @@
+name: "Release Azure PostgreSQL"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-postgresql/module.yaml
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-postgresql

--- a/.github/workflows/azure-postgresql.yaml
+++ b/.github/workflows/azure-postgresql.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-postgresql
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-postgresql

--- a/.github/workflows/azure-redis.yaml
+++ b/.github/workflows/azure-redis.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-redis
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-redis

--- a/.github/workflows/azure-redis.yaml
+++ b/.github/workflows/azure-redis.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Redis"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-redis/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-redis
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-redis

--- a/.github/workflows/azure-redis.yaml
+++ b/.github/workflows/azure-redis.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-redis/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-redis/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-speech-service.yaml
+++ b/.github/workflows/azure-speech-service.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-speech-service/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-speech-service/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-speech-service.yaml
+++ b/.github/workflows/azure-speech-service.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Speech Service"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-speech-service/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-speech-service
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-speech-service

--- a/.github/workflows/azure-speech-service.yaml
+++ b/.github/workflows/azure-speech-service.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-speech-service
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-speech-service

--- a/.github/workflows/azure-storage-account.yaml
+++ b/.github/workflows/azure-storage-account.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Storage Account"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-storage-account/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-storage-account
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-storage-account

--- a/.github/workflows/azure-storage-account.yaml
+++ b/.github/workflows/azure-storage-account.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-storage-account
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-storage-account

--- a/.github/workflows/azure-storage-account.yaml
+++ b/.github/workflows/azure-storage-account.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-storage-account/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-storage-account/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-unique-secrets-bundle.yaml
+++ b/.github/workflows/azure-unique-secrets-bundle.yaml
@@ -7,6 +7,11 @@ on:
       - main
     paths:
       - modules/azure-unique-secrets-bundle/module.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - modules/azure-unique-secrets-bundle/**
 
 jobs:
   validate:

--- a/.github/workflows/azure-unique-secrets-bundle.yaml
+++ b/.github/workflows/azure-unique-secrets-bundle.yaml
@@ -1,0 +1,20 @@
+name: "Release Azure Unique Secrets Bundle"
+
+on:
+  workflow_dispatch: # we allow manual runs as there are edge cases todo so (e.g. missed updating only the GitHub workflow or similar)
+  push:
+    branches:
+      - main
+    paths:
+      - modules/azure-unique-secrets-bundle/module.yaml
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/immutable-artifact.yaml
+    with:
+      module: azure-unique-secrets-bundle
+  release:
+    uses: ./.github/workflows/release.yaml
+    with:
+      module: azure-unique-secrets-bundle

--- a/.github/workflows/azure-unique-secrets-bundle.yaml
+++ b/.github/workflows/azure-unique-secrets-bundle.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       module: azure-unique-secrets-bundle
   release:
+    if: ${{ github.event.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/release.yaml
     with:
       module: azure-unique-secrets-bundle

--- a/.github/workflows/immutable-artifact.yaml
+++ b/.github/workflows/immutable-artifact.yaml
@@ -1,0 +1,53 @@
+name: "Validate Module Release"
+
+on:
+  workflow_call:
+    inputs:
+      module:
+        description: "Module to release"
+        required: true
+        type: string
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: |
+          npm install yaml
+
+      - id: validate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const yaml = require('yaml')
+            const fs = require('fs')
+
+            const modulePath = `modules/${{ inputs.module }}/module.yaml`
+            const moduleContent = fs.readFileSync(modulePath, 'utf8')
+            const moduleData = yaml.parse(moduleContent)
+
+            // Extract module name and version
+            const name = moduleData.name
+            const version = moduleData.version
+            const tagName = `${name}-${version}`
+
+            // Check if release already exists
+            try {
+              const existingRelease = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tagName
+              })
+              console.log(`❌ Release ${tagName} already exists`)
+              core.setFailed(`Release ${tagName} already exists. Cannot create duplicate release.`)
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`✅ Release ${tagName} does not exist, validation passed`)
+              } else {
+                throw error
+              }
+            }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,26 +1,13 @@
-name: "[terraform] Create Module Release"
+name: "Create Module Release"
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       module:
         description: "Module to release"
         required: true
-        type: choice
-        options:
-          - azure-application-gateway
-          - azure-bing-search
-          - azure-defender
-          - azure-document-intelligence
-          - azure-entra-app-registration
-          - azure-kubernetes-service
-          - azure-openai
-          - azure-postgresql
-          - azure-redis
-          - azure-speech-service
-          - azure-storage-account
-          - azure-unique-secrets-bundle
-          
+        type: string
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,4 +23,4 @@ Any breaking changes to a module (backwards incompatible) require a major versio
 
 ## Release
 
-To release a module, you can use the `[terraform] Create Module Release` workflow. For now sadly this action is manual we we would need some form of recurring action to automatically release changed modules. To be added later when we see this thing here flies 🕊️
+Modules are automatically released after merge given that `module.yaml` was modified (which should have been). If not, each release workflow has a dispatch handle.

--- a/modules/azure-openai/main.tf
+++ b/modules/azure-openai/main.tf
@@ -1,9 +1,9 @@
 locals {
   model_version_endpoints = [
-    for account in azurerm_cognitive_account.aca : {
+    for account_key, account in azurerm_cognitive_account.aca : {
       "endpoint" : account.endpoint,
       "location" : account.location,
-      "key" : var.cognitive_accounts[account.name].model_definitions_auth_strategy_injected == "ApiKey" ? (account.primary_access_key != null ? account.primary_access_key : local.key_placeholder) : "WORKLOAD_IDENTITY", # to be a real enum, this would need to be adjusted to support more than two values (switch instead of if/else so to say)
+      "key" : var.cognitive_accounts[account_key].model_definitions_auth_strategy_injected == "ApiKey" ? (account.primary_access_key != null ? account.primary_access_key : local.key_placeholder) : "WORKLOAD_IDENTITY", # to be a real enum, this would need to be adjusted to support more than two values (switch instead of if/else so to say)
       "models" : [
         for deployment in azurerm_cognitive_deployment.deployments : {
           "modelName" : deployment.model[0].name,

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -1,9 +1,9 @@
 name: azure-openai
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-openai
-version: 2.3.0
+version: 2.3.1
 compatibility:
   unique.ai: ~> 2025.16
 changes:
-  - kind: added
-    description: "Backward compatible exposure of the key inside the model definitions."
+  - kind: fixed
+    description: "Key lockup function now uses the map key instead of the account name which is unknown on initial apply."

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -6,4 +6,4 @@ compatibility:
   unique.ai: ~> 2025.16
 changes:
   - kind: fixed
-    description: "Key lockup function now uses the map key instead of the account name which is unknown on initial apply."
+    description: "Key lookup function now uses the map key instead of the account name which is unknown on initial apply."

--- a/modules/azure-openai/module.yaml
+++ b/modules/azure-openai/module.yaml
@@ -6,4 +6,4 @@ compatibility:
   unique.ai: ~> 2025.16
 changes:
   - kind: fixed
-    description: "Key lookup function now uses the map key instead of the account name which is unknown on initial apply."
+    description: "Key lookup function now uses the map key instead of the account name so name and key are not enforced to concidentally match again (key of terraform can be different than real name again/still)."


### PR DESCRIPTION
## Describe your changes

fixes
```
│     │ account.name is "oai-xxx-xxx-xxx-001"
│     │ var.cognitive_accounts is map of object with 1 element
│ 
│ The given key does not identify an element in this collection value.
```

which happens on initial apply as the account doesn't yet exist

Existing states do like this change.
<img width="923" height="687" alt="image" src="https://github.com/user-attachments/assets/39120676-6b58-48eb-8e88-6ca73e642428" />

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
