### PR TITLE
fix(agw): revert breaking defaults for protocol

### DIFF
--- a/modules/azure-application-gateway/main.tf
+++ b/modules/azure-application-gateway/main.tf
@@ -344,8 +344,8 @@ resource "azurerm_application_gateway" "appgw" {
   backend_http_settings {
     name                  = "${var.name_prefix}-be-htst"
     cookie_based_affinity = "Disabled"
-    port                  = 443
-    protocol              = "Https"
+    port                  = 80
+    protocol              = "Http"
   }
 
   # HTTP LISTENER - Traffic reception point
@@ -356,7 +356,7 @@ resource "azurerm_application_gateway" "appgw" {
     name                           = "${var.name_prefix}-httplstn"
     frontend_ip_configuration_name = local.active_frontend_ip_configuration_name
     frontend_port_name             = "${var.name_prefix}-feport"
-    protocol                       = "Https"
+    protocol                       = "Http"
   }
 
   # REQUEST ROUTING RULE - Traffic routing logic

--- a/modules/azure-application-gateway/module.yaml
+++ b/modules/azure-application-gateway/module.yaml
@@ -1,9 +1,9 @@
 name: azure-application-gateway
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-application-gateway
-version: 4.4.0
+version: 4.4.1
 compatibility:
   unique.ai: ~> 2025.32
 changes:
-  - kind: added
-    description: "Added tags for the application gateway."
+  - kind: fixed
+    description: "Default settings, that are supersed by AGIC anyway, default to HTTP again as else a certificate must be supplied."


### PR DESCRIPTION
## Describe your changes

patches
```
│ Application Gateway Name: "agw-x-prod"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: ApplicationGatewayHttpsListenerMustReferenceSslCert: Http Listener /subscriptions/x/resourceGroups/x/providers/Microsoft.Network/applicationGateways/agw-x-prod/httpListeners/agw-httplstn uses protocol Https. Ssl Certificate must be specified.
```

The issue is hidden for AGWs which were created before upgrading to these versions as AGIC controlls them (the values are _lifecycle_ignored_ anyway).

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
