### PR TITLE
feat(unique-secrets-bundle): ignore exp. date changes on manual secrets

### DIFF
--- a/modules/azure-postgresql/README.md
+++ b/modules/azure-postgresql/README.md
@@ -193,7 +193,7 @@ Before upgrading:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.68.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.15 |
 
 ## Modules
 

--- a/modules/azure-postgresql/README.md
+++ b/modules/azure-postgresql/README.md
@@ -193,7 +193,7 @@ Before upgrading:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.15 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.68.0 |
 
 ## Modules
 

--- a/modules/azure-unique-secrets-bundle/module.yaml
+++ b/modules/azure-unique-secrets-bundle/module.yaml
@@ -1,9 +1,9 @@
 name: azure-unique-secrets-bundle
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-unique-secrets-bundle
-version: 3.5.1
+version: 3.5.2
 compatibility:
   unique.ai: ~> 2025.30
 changes:
   - kind: fixed
-    description: "move mcp-hub-default-oauth-client-id and mcp-hub-default-oauth-client-secret to core key vault as manually-managed secrets"
+    description: "manual secrets now ignore changes to their expiration date."

--- a/modules/azure-unique-secrets-bundle/secrets.tf
+++ b/modules/azure-unique-secrets-bundle/secrets.tf
@@ -10,6 +10,6 @@ resource "azurerm_key_vault_secret" "manual_secret" {
   expiration_date = lookup(each.value, "expiration_date", "2099-12-31T23:59:59Z")
   content_type    = lookup(each.value, "content_type", "text/plain")
   lifecycle {
-    ignore_changes = [value, tags, content_type]
+    ignore_changes = [content_type, expiration_date, tags, value]
   }
 }


### PR DESCRIPTION
## Describe your changes

fixes the _one-time-per-manual-change_ perma-drifts.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)
