### PR TITLE
feat(azure-kubernetes-service): add Kata Containers node pool support

### DIFF
--- a/modules/azure-kubernetes-service/README.md
+++ b/modules/azure-kubernetes-service/README.md
@@ -106,12 +106,14 @@ Prometheus-based alerts are available when `azure_prometheus_grafana_monitor` is
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.39 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 2.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.39 |
 
 ## Modules
@@ -122,6 +124,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azapi_resource.kata_node_pool](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) | resource |
 | [azurerm_dashboard_grafana.grafana](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dashboard_grafana) | resource |
 | [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
@@ -166,6 +169,7 @@ No modules.
 | <a name="input_defender_log_analytics_workspace_id"></a> [defender\_log\_analytics\_workspace\_id](#input\_defender\_log\_analytics\_workspace\_id) | The ID of the Log Analytics Workspace for Microsoft Defender | `string` | `null` | no |
 | <a name="input_diagnostic_logs_categories"></a> [diagnostic\_logs\_categories](#input\_diagnostic\_logs\_categories) | AKS diagnostic log categories to enable. Only categories present in the supported set are used.<br/>See https://learn.microsoft.com/en-gb/azure/aks/monitor-aks-reference#resource-logs<br/><br/>DEPRECATED: Will be removed in the next major version as part of a breaking logging refactor. | `list(string)` | `null` | no |
 | <a name="input_dns_service_ip"></a> [dns\_service\_ip](#input\_dns\_service\_ip) | The DNS service IP for the Kubernetes Cluster. | `string` | `"172.20.0.10"` | no |
+| <a name="input_kata_node_pool_settings"></a> [kata\_node\_pool\_settings](#input\_kata\_node\_pool\_settings) | Settings for Kata Containers node pools with hardware-isolated VM workload runtime.<br/>Kata Containers provide strong isolation by running each container in a lightweight<br/>VM, offering an additional security boundary between containers and the host.<br/><br/>The following label and taint are automatically added to every Kata pool:<br/>  - Label: workload-runtime=kata<br/>  - Taint: workload-runtime=kata:NoSchedule<br/><br/>Workloads must tolerate the taint to be scheduled on Kata nodes. Use a RuntimeClass<br/>with handler 'kata' for pods that should run in Kata containers:<br/><br/>  apiVersion: node.k8s.io/v1<br/>  kind: RuntimeClass<br/>  metadata:<br/>    name: kata<br/>  handler: kata<br/>  scheduling:<br/>    nodeSelector:<br/>      workload-runtime: kata<br/>    tolerations:<br/>      - key: workload-runtime<br/>        operator: Equal<br/>        value: kata<br/>        effect: NoSchedule<br/><br/>Note: Kata node pools require VM sizes that support nested virtualization.<br/>The azapi provider is used because azurerm doesn't yet support KataVmIsolation workload\_runtime. | <pre>map(object({<br/>    vm_size              = string<br/>    min_count            = optional(number)<br/>    max_count            = optional(number)<br/>    max_pods             = optional(number)<br/>    os_disk_size_gb      = number<br/>    os_sku               = optional(string, "AzureLinux")<br/>    os_type              = optional(string, "Linux")<br/>    node_labels          = optional(map(string), {})<br/>    node_taints          = optional(list(string), [])<br/>    auto_scaling_enabled = bool<br/>    mode                 = optional(string, "User")<br/>    zones                = list(string)<br/>    subnet_nodes_id      = optional(string, null)<br/>    subnet_pods_id       = optional(string, null)<br/>    upgrade_settings = object({<br/>      max_surge = string<br/>    })<br/>  }))</pre> | `{}` | no |
 | <a name="input_kubernetes_default_node_count_max"></a> [kubernetes\_default\_node\_count\_max](#input\_kubernetes\_default\_node\_count\_max) | The maximum number of nodes in the default node pool. | `number` | `5` | no |
 | <a name="input_kubernetes_default_node_count_min"></a> [kubernetes\_default\_node\_count\_min](#input\_kubernetes\_default\_node\_count\_min) | The minimum number of nodes in the default node pool. | `number` | `2` | no |
 | <a name="input_kubernetes_default_node_os_disk_size"></a> [kubernetes\_default\_node\_os\_disk\_size](#input\_kubernetes\_default\_node\_os\_disk\_size) | The OS disk size in GB for default node pool VMs. | `number` | `100` | no |

--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -280,7 +280,6 @@ resource "azapi_resource" "kata_node_pool" {
   parent_id = azurerm_kubernetes_cluster.cluster.id
 
   body = {
-    tags = var.tags
     properties = {
       availabilityZones = each.value.zones
       count             = coalesce(each.value.min_count, 0)

--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -278,12 +278,12 @@ resource "azapi_resource" "kata_node_pool" {
   type      = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
   name      = each.key
   parent_id = azurerm_kubernetes_cluster.cluster.id
-  tags      = var.tags
 
   body = {
+    tags = var.tags
     properties = {
       availabilityZones = each.value.zones
-      count             = each.value.min_count
+      count             = coalesce(each.value.min_count, 0)
       enableAutoScaling = each.value.auto_scaling_enabled
       maxCount          = each.value.max_count
       maxPods           = each.value.max_pods

--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -226,7 +226,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool" {
   node_taints                 = each.value.node_taints
   os_disk_size_gb             = each.value.os_disk_size_gb
   os_sku                      = each.value.os_sku
-  os_type                     = each.value.os_type
   pod_subnet_id               = var.segregated_node_and_pod_subnets_enabled ? coalesce(each.value.subnet_pods_id, each.value.subnet_nodes_id, var.default_subnet_pods_id, var.default_subnet_nodes_id) : null
   tags                        = var.tags
   temporary_name_for_rotation = coalesce(each.value.temporary_name_for_rotation, "${each.key}repl")
@@ -266,5 +265,43 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot_node_pool" {
 
   upgrade_settings {
     max_surge = each.value.upgrade_settings.max_surge
+  }
+}
+
+# Using azapi_resource because azurerm provider doesn't yet support KataVmIsolation workload_runtime.
+# TODO: Switch back to azurerm_kubernetes_cluster_node_pool once support is released.
+# See: https://github.com/hashicorp/terraform-provider-azurerm/pull/31257
+resource "azapi_resource" "kata_node_pool" {
+  for_each = var.kata_node_pool_settings
+
+  type      = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
+  name      = each.key
+  parent_id = azurerm_kubernetes_cluster.cluster.id
+
+  body = {
+    properties = {
+      availabilityZones = each.value.zones
+      count             = each.value.min_count
+      enableAutoScaling = each.value.auto_scaling_enabled
+      maxCount          = each.value.max_count
+      maxPods           = each.value.max_pods
+      minCount          = each.value.min_count
+      mode              = each.value.mode
+      nodeLabels        = merge(each.value.node_labels, { "workload-runtime" = "kata" })
+      nodeTaints        = distinct(concat(["workload-runtime=kata:NoSchedule"], each.value.node_taints))
+      osDiskSizeGB      = each.value.os_disk_size_gb
+      osSKU             = each.value.os_sku
+      osType            = each.value.os_type
+      vmSize            = each.value.vm_size
+      vnetSubnetID      = coalesce(each.value.subnet_nodes_id, var.default_subnet_nodes_id)
+      workloadRuntime   = "KataVmIsolation"
+      upgradeSettings = {
+        maxSurge = each.value.upgrade_settings.max_surge
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -226,6 +226,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pool" {
   node_taints                 = each.value.node_taints
   os_disk_size_gb             = each.value.os_disk_size_gb
   os_sku                      = each.value.os_sku
+  os_type                     = each.value.os_type
   pod_subnet_id               = var.segregated_node_and_pod_subnets_enabled ? coalesce(each.value.subnet_pods_id, each.value.subnet_nodes_id, var.default_subnet_pods_id, var.default_subnet_nodes_id) : null
   tags                        = var.tags
   temporary_name_for_rotation = coalesce(each.value.temporary_name_for_rotation, "${each.key}repl")
@@ -269,7 +270,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot_node_pool" {
 }
 
 # Using azapi_resource because azurerm provider doesn't yet support KataVmIsolation workload_runtime.
-# TODO: Switch back to azurerm_kubernetes_cluster_node_pool once support is released.
+# Switch back to azurerm_kubernetes_cluster_node_pool once PR #31257 is released.
 # See: https://github.com/hashicorp/terraform-provider-azurerm/pull/31257
 resource "azapi_resource" "kata_node_pool" {
   for_each = var.kata_node_pool_settings
@@ -292,6 +293,7 @@ resource "azapi_resource" "kata_node_pool" {
       osDiskSizeGB      = each.value.os_disk_size_gb
       osSKU             = each.value.os_sku
       osType            = each.value.os_type
+      podSubnetID       = var.segregated_node_and_pod_subnets_enabled ? coalesce(each.value.subnet_pods_id, each.value.subnet_nodes_id, var.default_subnet_pods_id, var.default_subnet_nodes_id) : null
       vmSize            = each.value.vm_size
       vnetSubnetID      = coalesce(each.value.subnet_nodes_id, var.default_subnet_nodes_id)
       workloadRuntime   = "KataVmIsolation"

--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -278,6 +278,7 @@ resource "azapi_resource" "kata_node_pool" {
   type      = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
   name      = each.key
   parent_id = azurerm_kubernetes_cluster.cluster.id
+  tags      = var.tags
 
   body = {
     properties = {

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -2,9 +2,9 @@ name: azure-kubernetes-service
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-kubernetes-service
 # upcoming majors: overhaul complete logging setup (accomodating for Cilium network policies and their forwarded or dropped traffic logs)
-version: 5.5.0
+version: 5.6.0
 compatibility:
   unique.ai: ~> 2025.20
 changes:
   - kind: added
-    description: "Variables `diagnostic_logs_categories`, `basic_log_tables`, and `container_insights_streams` to configure AKS diagnostic logs and Container Insights streams; defaults preserve existing behavior. All three are deprecated and will be removed in the next major version as part of a breaking logging refactor."
+    description: "Variable `kata_node_pool_settings` to deploy Kata Containers node pools with hardware-isolated VM workload runtime (KataVmIsolation). Uses azapi provider pending azurerm support."

--- a/modules/azure-kubernetes-service/provider.tf
+++ b/modules/azure-kubernetes-service/provider.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.39"
     }
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.4"
+    }
   }
 }

--- a/modules/azure-kubernetes-service/variables.tf
+++ b/modules/azure-kubernetes-service/variables.tf
@@ -446,6 +446,7 @@ variable "kata_node_pool_settings" {
     mode                 = optional(string, "User")
     zones                = list(string)
     subnet_nodes_id      = optional(string, null)
+    subnet_pods_id       = optional(string, null)
     upgrade_settings = object({
       max_surge = string
     })

--- a/modules/azure-kubernetes-service/variables.tf
+++ b/modules/azure-kubernetes-service/variables.tf
@@ -402,6 +402,57 @@ variable "spot_node_pool_settings" {
   }
 }
 
+variable "kata_node_pool_settings" {
+  description = <<-EOT
+    Settings for Kata Containers node pools with hardware-isolated VM workload runtime.
+    Kata Containers provide strong isolation by running each container in a lightweight
+    VM, offering an additional security boundary between containers and the host.
+
+    The following label and taint are automatically added to every Kata pool:
+      - Label: workload-runtime=kata
+      - Taint: workload-runtime=kata:NoSchedule
+
+    Workloads must tolerate the taint to be scheduled on Kata nodes. Use a RuntimeClass
+    with handler 'kata' for pods that should run in Kata containers:
+
+      apiVersion: node.k8s.io/v1
+      kind: RuntimeClass
+      metadata:
+        name: kata
+      handler: kata
+      scheduling:
+        nodeSelector:
+          workload-runtime: kata
+        tolerations:
+          - key: workload-runtime
+            operator: Equal
+            value: kata
+            effect: NoSchedule
+
+    Note: Kata node pools require VM sizes that support nested virtualization.
+    The azapi provider is used because azurerm doesn't yet support KataVmIsolation workload_runtime.
+  EOT
+  type = map(object({
+    vm_size              = string
+    min_count            = optional(number)
+    max_count            = optional(number)
+    max_pods             = optional(number)
+    os_disk_size_gb      = number
+    os_sku               = optional(string, "AzureLinux")
+    os_type              = optional(string, "Linux")
+    node_labels          = optional(map(string), {})
+    node_taints          = optional(list(string), [])
+    auto_scaling_enabled = bool
+    mode                 = optional(string, "User")
+    zones                = list(string)
+    subnet_nodes_id      = optional(string, null)
+    upgrade_settings = object({
+      max_surge = string
+    })
+  }))
+  default = {}
+}
+
 variable "monitoring_account_name" {
   description = "The name of the monitoring account"
   default     = "MonitoringAccount1"


### PR DESCRIPTION
## Summary

- Add `kata_node_pool_settings` variable to deploy Kata Containers node pools with hardware-isolated VM workload runtime (KataVmIsolation)
- Add `azapi` provider (~> 2.4) since azurerm doesn't yet support KataVmIsolation workload_runtime
- Auto-apply label `workload-runtime=kata` and taint `workload-runtime=kata:NoSchedule` to Kata pools (matching spot pool convention)

## Usage

```hcl
kata_node_pool_settings = {
  kata = {
    vm_size              = "Standard_D8s_v5"
    min_count            = 0
    max_count            = 4
    max_pods             = 30
    os_disk_size_gb      = 100
    auto_scaling_enabled = true
    zones                = ["1", "3"]
    upgrade_settings     = { max_surge = "30%" }
  }
}
```

## Test plan

- [ ] Verify terraform fmt passes
- [ ] Verify terraform validate passes
- [ ] Deploy a Kata node pool in a test environment
- [ ] Verify workload-runtime label and taint are applied