### PR TITLE
fix(azure-kubernetes-service): activity-log alerts on child resources

### DIFF
--- a/.cursor/rules/module-yaml-changelog.mdc
+++ b/.cursor/rules/module-yaml-changelog.mdc
@@ -1,0 +1,49 @@
+---
+description: Conventions for editing modules/*/module.yaml (version + changelog)
+globs: modules/*/module.yaml
+alwaysApply: false
+---
+
+# `module.yaml` changelog is per-version, not cumulative
+
+The `changes:` list in `modules/<module>/module.yaml` describes **only the version being released in `version:`**. Prior entries belong to prior tags and have already been published as their GitHub release notes.
+
+`.github/workflows/release.yaml` reads the whole `changes:` array verbatim and posts it as the release notes for the new `${module}@${version}` tag. Leaving stale entries in re-publishes them under the new version and produces a misleading changelog.
+
+## When bumping `version:`
+
+1. Replace the entire `changes:` list with entries that describe only the diff between the previous and the new version.
+2. Do not append to the existing list. The historical record lives in git history and prior GitHub releases.
+3. Follow semver (see `CONTRIBUTING.md`): `fixed` → patch, `added` / `changed` (backwards-compatible) → minor, breaking → major.
+4. Allowed `kind:` values follow keep-a-changelog: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
+
+## Example
+
+Previous state (released as `azure-foo@1.2.0`):
+
+```yaml
+version: 1.2.0
+changes:
+  - kind: added
+    description: "Variable `bar` to configure baz."
+```
+
+Bumping to `1.2.1` for a bugfix — correct:
+
+```yaml
+version: 1.2.1
+changes:
+  - kind: fixed
+    description: "`bar` is now respected when baz is null."
+```
+
+Bumping to `1.2.1` for a bugfix — wrong (carries over the 1.2.0 entry):
+
+```yaml
+version: 1.2.1
+changes:
+  - kind: fixed
+    description: "`bar` is now respected when baz is null."
+  - kind: added
+    description: "Variable `bar` to configure baz."
+```

--- a/modules/azure-kubernetes-service/alerting.tf
+++ b/modules/azure-kubernetes-service/alerting.tf
@@ -17,8 +17,8 @@ resource "azurerm_monitor_activity_log_alert" "this" {
   location            = "global"
   tags                = var.tags
 
+  # No criteria.resource_id: it exact-matches and would drop child events (e.g. agentpools/write); scope covers them for Administrative.
   criteria {
-    resource_id    = azurerm_kubernetes_cluster.cluster.id
     operation_name = each.value.activity_log_criteria.operation_name
     category       = each.value.activity_log_criteria.category
     levels         = each.value.activity_log_criteria.levels

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -2,10 +2,12 @@ name: azure-kubernetes-service
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-kubernetes-service
 # upcoming majors: overhaul complete logging setup (accomodating for Cilium network policies and their forwarded or dropped traffic logs)
-version: 5.7.0
+version: 5.7.1
 compatibility:
   unique.ai: ~> 2025.20
 changes:
+  - kind: fixed
+    description: "Activity-log alerts (including the default `aks_agent_pool_write_error`) now actually fire. The previous `criteria.resource_id = <cluster id>` filter required an exact match and silently dropped events on child resources (e.g. `.../agentpools/<name>` writes). The cluster `scopes` value alone covers child resources for Administrative events."
   - kind: added
     description: "Plumb `drain_timeout_in_minutes`, `node_soak_duration_in_minutes` and `undrainable_node_behavior` through every pool's `upgrade_settings` (default pool via top-level vars, user/spot/kata pools via their `*_node_pool_settings.upgrade_settings` object). Lets consumers extend the drain budget for slow-to-evict workloads (Kata VMs, large stateful pods) and choose `Cordon` so a single stuck eviction doesn't fail the whole AKS upgrade."
   - kind: added

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -8,7 +8,3 @@ compatibility:
 changes:
   - kind: fixed
     description: "Activity-log alerts (including the default `aks_agent_pool_write_error`) now actually fire. The previous `criteria.resource_id = <cluster id>` filter required an exact match and silently dropped events on child resources (e.g. `.../agentpools/<name>` writes). The cluster `scopes` value alone covers child resources for Administrative events."
-  - kind: added
-    description: "Plumb `drain_timeout_in_minutes`, `node_soak_duration_in_minutes` and `undrainable_node_behavior` through every pool's `upgrade_settings` (default pool via top-level vars, user/spot/kata pools via their `*_node_pool_settings.upgrade_settings` object). Lets consumers extend the drain budget for slow-to-evict workloads (Kata VMs, large stateful pods) and choose `Cordon` so a single stuck eviction doesn't fail the whole AKS upgrade."
-  - kind: added
-    description: "Variable `kata_node_pool_settings` to deploy Kata Containers node pools with hardware-isolated VM workload runtime (KataVmIsolation). Uses azapi provider pending azurerm support."


### PR DESCRIPTION
## Describe your changes

Removes the `criteria.resource_id = <cluster id>` filter from the AKS activity-log alert resource. That field does an **exact** match against the event's `resourceId`, so events on child resources never matched and were silently dropped.

Concretely, the module's default alert:

```hcl
aks_agent_pool_write_error = {
  activity_log_criteria = {
    operation_name = "Microsoft.ContainerService/managedClusters/agentpools/write"
    category       = "Administrative"
    levels         = ["Error"]
    statuses       = ["Failed"]
  }
}
```

…has been dead code since v5: the `agentpools/write` event always has a child `resourceId` like `.../managedClusters/<x>/agentpools/<y>`, so the additional `criteria.resource_id = .../managedClusters/<x>` filter on the cluster-level id never matched.

Real-world hit: `aks-burger-prod` had a failed Kata agent-pool upgrade on 2026-05-24 (`"Upgrade Failed with status Unspecified, error: Unknown error"`) that produced a perfectly-shaped Activity Log entry — and the alert did not fire / nothing landed in Slack.

For activity log alerts in the `Administrative` category, `scopes` alone already covers child resources, so removing the over-constraining filter is sufficient.

Bumps module version 5.7.0 → 5.7.1 (patch / bugfix).

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable (`README.md`) — no public API change
- [x] Pre-Commit passed or has been run manually (`Makefile`)

## Follow-ups (out of scope for this PR)
- Bump `ref` in monorepo consumers (`infrastructure/providers/azure/unique-ag/tenants/**/30-aks.tf`) from `56d76db` (5.7.0) to the new 5.7.1 tag so all 9 clusters get the working alert.