### PR TITLE
fix(aks): set scale_down_delay_after_delete to 2m for Cilium stability

### DIFF
--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -145,6 +145,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
       skip_nodes_with_local_storage    = false
       expander                         = "least-waste"
       scale_down_unneeded              = "10m"
+      scale_down_delay_after_delete    = "2m"
       scale_down_utilization_threshold = 0.6
     }
   }

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -2,9 +2,9 @@ name: azure-kubernetes-service
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-kubernetes-service
 # upcoming majors: overhaul complete logging setup (accomodating for Cilium network policies and their forwarded or dropped traffic logs)
-version: 6.1.0
+version: 6.2.0
 compatibility:
   unique.ai: ~> 2025.20
 changes:
   - kind: added
-    description: "For the default node pool, added the `os_sku` property to specify the OS SKU."
+    description: "Set `scale_down_delay_after_delete` to `2m` to prevent Cilium BPF state corruption during rapid consecutive node deletions by the cluster autoscaler."


### PR DESCRIPTION
## Describe your changes

Sets `scale_down_delay_after_delete = "2m"` in the `auto_scaler_profile` block of the AKS module.

### Problem

The cluster autoscaler's default delay of 10 seconds between consecutive node deletions is insufficient for Cilium to finish reconciling its BPF state before the next deletion begins.

When a node is deleted, Cilium must rewrite the ipcache, reload BPF programs, and rebuild FQDN policy tables across **all remaining nodes** in the cluster. This takes 1–3 minutes cluster-wide. With a 10s window, a second deletion starts before the first reconciliation completes, leaving nodes in a partially inconsistent BPF state.

**Observed symptoms on aks-unique-uat01 (2026-06-17):**
- Hubble shows DNS drops with `Unknown drop reason` targeting CoreDNS
- Pods get `EAI_AGAIN` / `EREFUSED` resolving PostgreSQL and external hostnames
- Applications return intermittent 500 errors
- Cilium agent restart on each affected node required to recover

Root cause: documented upstream at cilium/cilium#29322 and cilium/cilium#44714.

### Fix

2m gives Cilium a full uninterrupted reconciliation window between scale-down events. This is appropriate for all clusters using this module since it already hardcodes `network_data_plane = "cilium"`.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`) — bumped to `6.2.0`
- [x] Changelog updated (`module.yaml`)
- [ ] Compatibility updated where applicable (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)