### PR TITLE
fix(azure-application-gateway): allow MCP Hub OAuth DCR redirect_uris with localhost

### DIFF
--- a/modules/azure-application-gateway/variables.tf
+++ b/modules/azure-application-gateway/variables.tf
@@ -604,6 +604,20 @@ variable "waf_managed_rules" {
           version         = "3.2"
           rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
         }
+      },
+      # MCP Hub OAuth dynamic client registration (RFC 7591) sends redirect_uris with
+      # http://127.0.0.1:<port> for VS Code and other external MCP clients. OWASP CRS
+      # 931100 false-positives on that JSON field (RFI: URL parameter using IP address).
+      {
+        match_variable          = "RequestArgNames"
+        selector                = "redirect_uris"
+        selector_match_operator = "Equals"
+        excluded_rule_set = {
+          type            = "OWASP"
+          version         = "3.2"
+          excluded_rules  = ["931100"]
+          rule_group_name = "REQUEST-931-APPLICATION-ATTACK-RFI"
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Adds a scoped WAF exclusion for OWASP CRS rule **931100** on the `redirect_uris` request arg
- Fixes MCP Hub OAuth dynamic client registration (RFC 7591) being blocked when external MCP clients (e.g. VS Code) register with `http://127.0.0.1:<port>` redirect URIs

## Context
On UAT1, `POST /mcp-hub/*/register` was blocked by Azure Application Gateway WAF (rule 931100 — REQUEST-931-APPLICATION-ATTACK-RFI: URL parameter using IP address). VS Code requires localhost redirect URIs for OAuth, causing "Dynamic Client Registration not supported" errors.

## Test plan
- [ ] Atlantis/terraform apply on UAT01 AGW stack after bumping module ref
- [ ] Verify `POST https://api.uat1.unique.app/mcp-hub/<slug>/register` with `redirect_uris: ["http://127.0.0.1:33418", "https://vscode.dev/redirect"]` returns `201`
- [ ] Confirm VS Code MCP virtual server connection completes OAuth registration


Made with [Cursor](https://cursor.com)