### PR TITLE
feat(azure-defender): add workspace_settings to route data to a custom Log Analytics workspace

### DIFF
--- a/modules/azure-defender/README.md
+++ b/modules/azure-defender/README.md
@@ -6,6 +6,7 @@ This Terraform code configures Azure Defender for a subscription, enabling vario
 ## Pre-requisites
 - Contributor access to the subscription
 - If using Event Hub export: Access to the Event Hub connection string (can be in any subscription)
+- If using `workspace_settings`: Owner access to the subscription
 
 ## Features
 - Configure Defender plans for various Azure services (Cloud Posture, Storage, VMs, Key Vaults, ARM, Databases, Containers, AI)
@@ -13,6 +14,9 @@ This Terraform code configures Azure Defender for a subscription, enabling vario
 - **Optional: Continuous export to Event Hub** (alerts, assessments, secure scores)
   - Supports cross-subscription Event Hub export for centralized logging
   - For cross-subscription scenarios, use provider aliases or data sources to retrieve the connection string
+- **Optional: Custom Log Analytics workspace** (`workspace_settings`)
+  - Routes Defender agent data to a workspace you control
+  - Without it, Azure auto-provisions `DefaultWorkspace-<subscription-id>-<geo>` in `DefaultResourceGroup-<geo>` per geo, outside of Terraform state
 
 ## Default settings
 
@@ -63,6 +67,7 @@ No modules.
 | [azurerm_security_center_automation.eventhub_export](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_automation) | resource |
 | [azurerm_security_center_subscription_pricing.free_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_subscription_pricing) | resource |
 | [azurerm_security_center_subscription_pricing.standard_plan](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_subscription_pricing) | resource |
+| [azurerm_security_center_workspace.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_workspace) | resource |
 
 ## Inputs
 
@@ -79,6 +84,7 @@ No modules.
 | <a name="input_storage_accounts_defender_settings"></a> [storage\_accounts\_defender\_settings](#input\_storage\_accounts\_defender\_settings) | n/a | <pre>object({<br/>    tier    = optional(string, "Standard")<br/>    subplan = optional(string, "DefenderForStorageV2")<br/>    extensions = optional(list(object({<br/>      name                            = string<br/>      additional_extension_properties = optional(map(string))<br/>    })), [])<br/>  })</pre> | <pre>{<br/>  "extensions": [<br/>    {<br/>      "additional_extension_properties": {<br/>        "AutomatedResponse": "None",<br/>        "BlobScanResultsOptions": "BlobIndexTags",<br/>        "CapGBPerMonthPerStorageAccount": "1000"<br/>      },<br/>      "name": "OnUploadMalwareScanning"<br/>    },<br/>    {<br/>      "name": "SensitiveDataDiscovery"<br/>    }<br/>  ]<br/>}</pre> | no |
 | <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Subscription ID | `string` | n/a | yes |
 | <a name="input_virtual_machines_defender_settings"></a> [virtual\_machines\_defender\_settings](#input\_virtual\_machines\_defender\_settings) | n/a | <pre>object({<br/>    tier    = optional(string, "Standard")<br/>    subplan = optional(string, "P2")<br/>    extensions = optional(list(object({<br/>      name                            = string<br/>      additional_extension_properties = optional(map(string))<br/>    })), [])<br/>  })</pre> | <pre>{<br/>  "extensions": [<br/>    {<br/>      "additional_extension_properties": {<br/>        "ExclusionTags": "[]"<br/>      },<br/>      "name": "AgentlessVmScanning"<br/>    }<br/>  ]<br/>}</pre> | no |
+| <a name="input_workspace_settings"></a> [workspace\_settings](#input\_workspace\_settings) | Log Analytics workspace that Defender for Cloud agents send their data to. When unset, Azure auto-provisions a default workspace per geo (DefaultWorkspace-<subscription-id>-<geo> in DefaultResourceGroup-<geo>). scope defaults to the subscription. | <pre>object({<br/>    workspace_id = string<br/>    scope        = optional(string)<br/>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/modules/azure-defender/README.md
+++ b/modules/azure-defender/README.md
@@ -17,6 +17,7 @@ This Terraform code configures Azure Defender for a subscription, enabling vario
 - **Optional: Custom Log Analytics workspace** (`workspace_settings`)
   - Routes Defender agent data to a workspace you control
   - Without it, Azure auto-provisions `DefaultWorkspace-<subscription-id>-<geo>` in `DefaultResourceGroup-<geo>` per geo, outside of Terraform state
+  - Applied before any pricing plan is enabled, so greenfield applies never hit the auto-provisioning window
 
 ## Default settings
 

--- a/modules/azure-defender/examples/custom-workspace/main.tf
+++ b/modules/azure-defender/examples/custom-workspace/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "rg-defender-workspace-example"
+  location = "Switzerland North"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "log-defender-example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+module "defender" {
+  source          = "../.."
+  subscription_id = data.azurerm_subscription.current.id
+  security_contact_settings = {
+    email = "example@example.com"
+  }
+  # Routes Defender data to this workspace instead of the auto-provisioned
+  # DefaultWorkspace-<subscription-id>-<geo> in DefaultResourceGroup-<geo>
+  workspace_settings = {
+    workspace_id = azurerm_log_analytics_workspace.example.id
+  }
+}

--- a/modules/azure-defender/main.tf
+++ b/modules/azure-defender/main.tf
@@ -41,6 +41,14 @@ locals {
   defender_configs_standard_plan = [for config in local.defender_configs : config if config.config.tier == "Standard"]
 }
 
+resource "azurerm_security_center_workspace" "default" {
+  count        = var.workspace_settings != null ? 1 : 0
+  scope        = coalesce(var.workspace_settings.scope, var.subscription_id)
+  workspace_id = var.workspace_settings.workspace_id
+}
+
+# Pricing plans depend on the workspace setting: enabling a plan without it makes
+# Azure auto-provision DefaultWorkspace-<subscription-id>-<geo> on greenfield applies.
 resource "azurerm_security_center_subscription_pricing" "standard_plan" {
   for_each      = { for config in local.defender_configs_standard_plan : config.resource_type => config }
   resource_type = each.value.resource_type
@@ -54,17 +62,15 @@ resource "azurerm_security_center_subscription_pricing" "standard_plan" {
       additional_extension_properties = extension.value.additional_extension_properties
     }
   }
+
+  depends_on = [azurerm_security_center_workspace.default]
 }
 resource "azurerm_security_center_subscription_pricing" "free_plan" {
   for_each      = { for config in local.defender_configs_free_plan : config.resource_type => config }
   resource_type = each.value.resource_type
   tier          = each.value.config.tier
-}
 
-resource "azurerm_security_center_workspace" "default" {
-  count        = var.workspace_settings != null ? 1 : 0
-  scope        = coalesce(var.workspace_settings.scope, var.subscription_id)
-  workspace_id = var.workspace_settings.workspace_id
+  depends_on = [azurerm_security_center_workspace.default]
 }
 
 resource "azapi_resource" "security_contact" {

--- a/modules/azure-defender/main.tf
+++ b/modules/azure-defender/main.tf
@@ -61,6 +61,12 @@ resource "azurerm_security_center_subscription_pricing" "free_plan" {
   tier          = each.value.config.tier
 }
 
+resource "azurerm_security_center_workspace" "default" {
+  count        = var.workspace_settings != null ? 1 : 0
+  scope        = coalesce(var.workspace_settings.scope, var.subscription_id)
+  workspace_id = var.workspace_settings.workspace_id
+}
+
 resource "azapi_resource" "security_contact" {
   type = "Microsoft.Security/securityContacts@2023-12-01-preview"
   # The only valid name for security contact is 'default'

--- a/modules/azure-defender/module.yaml
+++ b/modules/azure-defender/module.yaml
@@ -1,8 +1,7 @@
 name: azure-defender
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-defender
-version: 2.5.0
+version: 2.6.0
 changes:
   - kind: added
-    description: "Support for Event Hub export"
-
+    description: "Variable `workspace_settings` to route Defender for Cloud data to a custom Log Analytics workspace instead of the auto-provisioned default workspace"

--- a/modules/azure-defender/variables.tf
+++ b/modules/azure-defender/variables.tf
@@ -184,6 +184,15 @@ variable "ai_defender_settings" {
   default = {}
 }
 
+variable "workspace_settings" {
+  description = "Log Analytics workspace that Defender for Cloud agents send their data to. When unset, Azure auto-provisions a default workspace per geo (DefaultWorkspace-<subscription-id>-<geo> in DefaultResourceGroup-<geo>). scope defaults to the subscription."
+  type = object({
+    workspace_id = string
+    scope        = optional(string)
+  })
+  default = null
+}
+
 variable "eventhub_export" {
   description = "Configuration for exporting Defender for Cloud data to Event Hub."
   type = object({


### PR DESCRIPTION
## Describe your changes

Defender for Cloud auto-provisions a per-geo Log Analytics workspace (`DefaultWorkspace-<subscription-id>-<geo>` in `DefaultResourceGroup-<geo>`) whenever its plans are enabled and no workspace setting exists — outside of Terraform state (see e.g. `lz-sparkles-prod` / Switzerland North).

This adds an optional `workspace_settings` variable that manages the subscription's `Microsoft.Security/workspaceSettings/default` via `azurerm_security_center_workspace`, so Defender agent data lands in a workspace we control instead. `scope` defaults to the subscription; default stays `null`, so existing consumers are unaffected.

- New example `examples/custom-workspace`
- Requires Owner on the subscription when used (documented in README pre-requisites)

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`) — 2.5.0 → 2.6.0
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`) — tf-docs, fmt, and example validation run locally

Made with [Cursor](https://cursor.com)