### PR TITLE
fix(azure-storage-account): don't emit blob_properties for FileStorage accounts

### DIFF
--- a/modules/azure-storage-account/main.tf
+++ b/modules/azure-storage-account/main.tf
@@ -44,39 +44,43 @@ resource "azurerm_storage_account" "storage_account" {
   nfsv3_enabled  = var.is_nfs_mountable
   is_hns_enabled = var.is_nfs_mountable
 
-  blob_properties {
-    change_feed_enabled           = local.change_feed_enabled
-    change_feed_retention_in_days = local.change_feed_enabled ? var.data_protection_settings.change_feed_retention_days : null
-    versioning_enabled            = var.data_protection_settings.versioning_enabled
-    dynamic "cors_rule" {
-      for_each = var.cors_rules
-      content {
-        allowed_origins    = cors_rule.value.allowed_origins
-        allowed_methods    = cors_rule.value.allowed_methods
-        allowed_headers    = cors_rule.value.allowed_headers
-        exposed_headers    = cors_rule.value.exposed_headers
-        max_age_in_seconds = cors_rule.value.max_age_in_seconds
+  # blob_properties is unsupported on FileStorage accounts (Azure Files has no blob service).
+  dynamic "blob_properties" {
+    for_each = var.account_kind != "FileStorage" ? [1] : []
+    content {
+      change_feed_enabled           = local.change_feed_enabled
+      change_feed_retention_in_days = local.change_feed_enabled ? var.data_protection_settings.change_feed_retention_days : null
+      versioning_enabled            = var.data_protection_settings.versioning_enabled
+      dynamic "cors_rule" {
+        for_each = var.cors_rules
+        content {
+          allowed_origins    = cors_rule.value.allowed_origins
+          allowed_methods    = cors_rule.value.allowed_methods
+          allowed_headers    = cors_rule.value.allowed_headers
+          exposed_headers    = cors_rule.value.exposed_headers
+          max_age_in_seconds = cors_rule.value.max_age_in_seconds
+        }
       }
-    }
 
-    dynamic "container_delete_retention_policy" {
-      for_each = var.data_protection_settings.container_soft_delete_retention_days > 0 ? [1] : []
-      content {
-        days = var.data_protection_settings.container_soft_delete_retention_days
+      dynamic "container_delete_retention_policy" {
+        for_each = var.data_protection_settings.container_soft_delete_retention_days > 0 ? [1] : []
+        content {
+          days = var.data_protection_settings.container_soft_delete_retention_days
+        }
       }
-    }
 
-    dynamic "delete_retention_policy" {
-      for_each = var.data_protection_settings.blob_soft_delete_retention_days > 0 ? [1] : []
-      content {
-        days                     = var.data_protection_settings.blob_soft_delete_retention_days
-        permanent_delete_enabled = false
+      dynamic "delete_retention_policy" {
+        for_each = var.data_protection_settings.blob_soft_delete_retention_days > 0 ? [1] : []
+        content {
+          days                     = var.data_protection_settings.blob_soft_delete_retention_days
+          permanent_delete_enabled = false
+        }
       }
-    }
-    dynamic "restore_policy" {
-      for_each = var.data_protection_settings.point_in_time_restore_days > 0 ? [1] : []
-      content {
-        days = var.data_protection_settings.point_in_time_restore_days
+      dynamic "restore_policy" {
+        for_each = var.data_protection_settings.point_in_time_restore_days > 0 ? [1] : []
+        content {
+          days = var.data_protection_settings.point_in_time_restore_days
+        }
       }
     }
   }

--- a/modules/azure-storage-account/module.yaml
+++ b/modules/azure-storage-account/module.yaml
@@ -1,7 +1,7 @@
 name: azure-storage-account
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-storage-account
-version: 7.2.0
+version: 7.1.1
 compatibility:
   unique.ai: ~> 2025.24
 changes:

--- a/modules/azure-storage-account/module.yaml
+++ b/modules/azure-storage-account/module.yaml
@@ -1,9 +1,9 @@
 name: azure-storage-account
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-storage-account
-version: 7.1.0
+version: 7.2.0
 compatibility:
   unique.ai: ~> 2025.24
 changes:
-  - kind: added
-    description: "Variable `https_traffic_only_enabled` (default `true`, preserving prior behavior) to allow disabling HTTPS-only REST traffic, required for NFS Azure File shares which do not support in-protocol TLS."
+  - kind: fixed
+    description: "`blob_properties` is no longer emitted for `FileStorage`-kind accounts (e.g. Premium NFS Azure File shares), which don't have a blob service and previously failed to apply with `blob_properties aren't supported for account kind \"FileStorage\"`."


### PR DESCRIPTION
## Describe your changes

`azurerm_storage_account.storage_account`'s `blob_properties` block was always emitted regardless of `account_kind`. Azure Files (`FileStorage` kind, used for Premium NFS shares) has no blob service and rejects it at apply time:

```
Error: `blob_properties` aren't supported for account kind "FileStorage" in sku tier "Premium"
```

`blob_properties` is now wrapped in a `dynamic` block, only emitted when `account_kind != "FileStorage"`. No behavior change for any other account kind.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable  (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)