### PR TITLE
fix(azure-kubernetes-service): stop reverting autoscaler-managed kata node pool count

### DIFF
--- a/modules/azure-kubernetes-service/README.md
+++ b/modules/azure-kubernetes-service/README.md
@@ -137,6 +137,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azapi_resource.kata_node_pool](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) | resource |
+| [azapi_resource.kata_node_pool_fixed_count](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) | resource |
 | [azurerm_dashboard_grafana.grafana](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dashboard_grafana) | resource |
 | [azurerm_kubernetes_cluster.cluster](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |

--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -6,6 +6,37 @@ locals {
     time_format_regex  = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$"
     utc_offset_regex   = "^[+-]([01]?[0-9]|2[0-3]):[0-5][0-9]$"
   }
+
+  kata_node_pool_body = {
+    for k, v in var.kata_node_pool_settings : k => {
+      properties = {
+        availabilityZones = v.zones
+        count             = coalesce(v.min_count, 0)
+        enableAutoScaling = v.auto_scaling_enabled
+        maxCount          = v.max_count
+        maxPods           = v.max_pods
+        minCount          = v.min_count
+        mode              = v.mode
+        nodeLabels        = merge(v.node_labels, { "workload-runtime" = "kata" })
+        nodeTaints        = distinct(concat(["workload-runtime=kata:NoSchedule"], v.node_taints))
+        osDiskSizeGB      = v.os_disk_size_gb
+        osSKU             = v.os_sku
+        osType            = v.os_type
+        podSubnetID       = var.segregated_node_and_pod_subnets_enabled ? coalesce(v.subnet_pods_id, v.subnet_nodes_id, var.default_subnet_pods_id, var.default_subnet_nodes_id) : null
+        vmSize            = v.vm_size
+        vnetSubnetID      = coalesce(v.subnet_nodes_id, var.default_subnet_nodes_id)
+        workloadRuntime   = "KataVmIsolation"
+        upgradeSettings = {
+          maxSurge                  = v.upgrade_settings.max_surge
+          drainTimeoutInMinutes     = v.upgrade_settings.drain_timeout_in_minutes
+          nodeSoakDurationInMinutes = v.upgrade_settings.node_soak_duration_in_minutes
+          undrainableNodeBehavior   = v.upgrade_settings.undrainable_node_behavior
+        }
+      }
+    }
+  }
+  kata_node_pool_autoscaled_settings  = { for k, v in var.kata_node_pool_settings : k => v if v.auto_scaling_enabled }
+  kata_node_pool_fixed_count_settings = { for k, v in var.kata_node_pool_settings : k => v if !v.auto_scaling_enabled }
 }
 
 resource "azurerm_kubernetes_cluster" "cluster" {
@@ -295,39 +326,34 @@ resource "azurerm_kubernetes_cluster_node_pool" "spot_node_pool" {
 # Using azapi_resource because azurerm provider doesn't yet support KataVmIsolation workload_runtime.
 # Switch back to azurerm_kubernetes_cluster_node_pool once PR #31257 is released.
 # See: https://github.com/hashicorp/terraform-provider-azurerm/pull/31257
+#
+# Split into two resources by auto_scaling_enabled because lifecycle.ignore_changes can't be
+# conditioned per for_each instance. Once autoscaling is enabled, AKS's cluster-autoscaler owns
+# the live node count independently of Terraform, so re-asserting count = min_count on every plan
+# only fights the autoscaler and shows up as permanent drift. Toggling a pool's auto_scaling_enabled
+# moves it between these two resource addresses, which forces a destroy/recreate unless a moved
+# block is added at that time.
 resource "azapi_resource" "kata_node_pool" {
-  for_each = var.kata_node_pool_settings
+  for_each = local.kata_node_pool_autoscaled_settings
 
   type      = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
   name      = each.key
   parent_id = azurerm_kubernetes_cluster.cluster.id
+  body      = local.kata_node_pool_body[each.key]
 
-  body = {
-    properties = {
-      availabilityZones = each.value.zones
-      count             = coalesce(each.value.min_count, 0)
-      enableAutoScaling = each.value.auto_scaling_enabled
-      maxCount          = each.value.max_count
-      maxPods           = each.value.max_pods
-      minCount          = each.value.min_count
-      mode              = each.value.mode
-      nodeLabels        = merge(each.value.node_labels, { "workload-runtime" = "kata" })
-      nodeTaints        = distinct(concat(["workload-runtime=kata:NoSchedule"], each.value.node_taints))
-      osDiskSizeGB      = each.value.os_disk_size_gb
-      osSKU             = each.value.os_sku
-      osType            = each.value.os_type
-      podSubnetID       = var.segregated_node_and_pod_subnets_enabled ? coalesce(each.value.subnet_pods_id, each.value.subnet_nodes_id, var.default_subnet_pods_id, var.default_subnet_nodes_id) : null
-      vmSize            = each.value.vm_size
-      vnetSubnetID      = coalesce(each.value.subnet_nodes_id, var.default_subnet_nodes_id)
-      workloadRuntime   = "KataVmIsolation"
-      upgradeSettings = {
-        maxSurge                  = each.value.upgrade_settings.max_surge
-        drainTimeoutInMinutes     = each.value.upgrade_settings.drain_timeout_in_minutes
-        nodeSoakDurationInMinutes = each.value.upgrade_settings.node_soak_duration_in_minutes
-        undrainableNodeBehavior   = each.value.upgrade_settings.undrainable_node_behavior
-      }
-    }
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [body.properties.count]
   }
+}
+
+resource "azapi_resource" "kata_node_pool_fixed_count" {
+  for_each = local.kata_node_pool_fixed_count_settings
+
+  type      = "Microsoft.ContainerService/managedClusters/agentPools@2025-10-01"
+  name      = each.key
+  parent_id = azurerm_kubernetes_cluster.cluster.id
+  body      = local.kata_node_pool_body[each.key]
 
   lifecycle {
     create_before_destroy = true

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -1,13 +1,9 @@
 name: azure-kubernetes-service
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-kubernetes-service
-version: 7.0.0
+version: 7.0.1
 compatibility:
   unique.ai: ~> 2025.20
 changes:
-  - kind: removed
-    description: "Variables `diagnostic_logs_categories`, `container_insights_streams`, `container_insights_enabled`, `basic_log_tables`, `log_table_plan`, and `retention_in_days`. Log Analytics workspace table resources are no longer managed by this module."
-  - kind: added
-    description: "Variables `control_plane_logs` and `data_plane_logs` to configure AKS control-plane diagnostic logs and Container Insights data-plane telemetry independently. `data_plane_logs.enabled` defaults to `false` (was implicitly always on when `log_analytics_workspace` was set)."
-  - kind: changed
-    description: "Default AKS control-plane diagnostic log categories now include only `cluster-autoscaler`. Pass the previous category list explicitly via `control_plane_logs.categories` to preserve all old control-plane logs."
+  - kind: fixed
+    description: "`kata_node_pool_settings` entries with `auto_scaling_enabled = true` no longer show permanent plan drift on `count`. The cluster-autoscaler owns the live node count once autoscaling is enabled, so Terraform now ignores changes to it after creation instead of reverting it back to `min_count` on every plan."


### PR DESCRIPTION
## Describe your changes

The `kata_node_pool` `azapi_resource` re-asserts `count = coalesce(min_count, 0)` in its `body.properties` on every plan. Once `auto_scaling_enabled = true` (every real usage today), AKS's cluster-autoscaler owns the live node count independently of Terraform, so this shows up as permanent, unrelated plan drift on every PR that touches an affected Atlantis project (e.g. [monorepo#26969](https://github.com/Unique-AG/monorepo/pull/26969#issuecomment-5201311730), a Renovate dependency bump with no infra changes).

Fix: split the resource by `auto_scaling_enabled` (Terraform's `lifecycle.ignore_changes` can't be conditioned per `for_each` instance):
- `azapi_resource.kata_node_pool` (unchanged address) now only covers autoscaled pools and ignores `body.properties.count` after creation.
- New `azapi_resource.kata_node_pool_fixed_count` covers non-autoscaled pools (none exist today) and keeps full count management.

The shared `body` construction was factored into `local.kata_node_pool_body` to avoid duplicating it across both resources.

No existing resource addresses change, so this ships with zero plan diff for current tenants beyond the intended fix, and doesn't need a `moved {}` block.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] `Contribution Guideline` read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable (`README.md`)
- [ ] Pre-Commit passed or has been run manually (`Makefile`)