### PR TITLE
fix(azure-log-analytics-workspace): wait for workspace propagation before creating DCR

### DIFF
--- a/modules/azure-log-analytics-workspace/README.md
+++ b/modules/azure-log-analytics-workspace/README.md
@@ -81,6 +81,7 @@ Set `data_collection_rule = null` or `data_collection_rule = { enabled = false }
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.15 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.13 |
 
 ## Providers
 
@@ -88,6 +89,7 @@ Set `data_collection_rule = null` or `data_collection_rule = { enabled = false }
 |------|---------|
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 2.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.15 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.13 |
 
 ## Modules
 
@@ -102,6 +104,7 @@ No modules.
 | [azurerm_log_analytics_workspace_table.basic_log_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace_table) | resource |
 | [azurerm_monitor_data_collection_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_rule) | resource |
 | [azurerm_monitor_diagnostic_setting.dcr_log_errors](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [time_sleep.wait_for_workspace_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs
 

--- a/modules/azure-log-analytics-workspace/main.tf
+++ b/modules/azure-log-analytics-workspace/main.tf
@@ -45,6 +45,13 @@ resource "azurerm_log_analytics_workspace_table" "basic_log_table" {
   workspace_id            = azurerm_log_analytics_workspace.this.id
 }
 
+resource "time_sleep" "wait_for_workspace_propagation" {
+  count = local.dcr_enabled ? 1 : 0
+
+  depends_on      = [azurerm_log_analytics_workspace.this]
+  create_duration = "30s"
+}
+
 resource "azurerm_monitor_data_collection_rule" "this" {
   count               = local.dcr_enabled ? 1 : 0
   kind                = "WorkspaceTransforms"
@@ -52,6 +59,8 @@ resource "azurerm_monitor_data_collection_rule" "this" {
   name                = local.dcr_name
   resource_group_name = var.resource_group_name
   tags                = var.tags
+
+  depends_on = [time_sleep.wait_for_workspace_propagation]
 
   destinations {
     log_analytics {

--- a/modules/azure-log-analytics-workspace/module.yaml
+++ b/modules/azure-log-analytics-workspace/module.yaml
@@ -1,7 +1,7 @@
 name: azure-log-analytics-workspace
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-log-analytics-workspace
-version: 1.2.1
+version: 1.2.2
 changes:
   - kind: fixed
-    description: "Remove unsupported log_analytics_destination_type from DCR."
+    description: "Wait for workspace propagation before creating the data collection rule to avoid an `InvalidPayload` race on newly created workspaces."

--- a/modules/azure-log-analytics-workspace/provider.tf
+++ b/modules/azure-log-analytics-workspace/provider.tf
@@ -9,5 +9,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.15"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
   }
 }


### PR DESCRIPTION
## Describe your changes

Newly created Log Analytics workspaces are not immediately ready to accept a `WorkspaceTransforms` DCR. Terraform issues the DCR-create call as soon as the workspace-create call returns, and Azure Resource Manager needs a short additional window before the workspace is queryable/writable enough — this races and Azure returns a generic `InvalidPayload: Data collection rule is invalid` 400. This is a known azurerm-provider/Azure Monitor issue reported on brand-new workspaces (see [hashicorp/terraform-provider-azurerm#21897](https://github.com/hashicorp/terraform-provider-azurerm/issues/21897)).

This module already lacked the mitigation used elsewhere in this repo (`modules/azure-entra-app-registration-argocd`): a `time_sleep` gated on the same `count` condition as the dependent resource, chained via `depends_on`.

- Add `time_sleep.wait_for_workspace_propagation` (30s, only when `local.dcr_enabled`), depending on `azurerm_log_analytics_workspace.this`.
- `azurerm_monitor_data_collection_rule.this` now depends on that sleep.
- Bump module version to `1.2.2` with a `fixed` changelog entry.
- Regenerate README (requirements/providers/resources tables) for the new `time` provider requirement.

Existing tenants are unaffected: `time_sleep` only runs its delay on resource creation, and their DCR already exists in state, so adding `depends_on` alone doesn't force replacement.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] `Contribution Guideline` read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)