### PR TITLE
fix(azure-defender): import subscription-singleton resources instead of failing on already-exists

### DIFF
--- a/modules/azure-defender/main.tf
+++ b/modules/azure-defender/main.tf
@@ -61,6 +61,27 @@ resource "azurerm_security_center_subscription_pricing" "free_plan" {
   tier          = each.value.config.tier
 }
 
+# Defender pricing tiers and the security contact are subscription-level singletons: Azure never
+# deletes them, `terraform destroy` just resets pricing to Free. A create after that reset (or after
+# any state loss) then fails with "already exists". `import` is a no-op once the address is already
+# in state, so this is safe for tenants that have applied successfully before too.
+import {
+  for_each = { for config in local.defender_configs_standard_plan : config.resource_type => config }
+  to       = azurerm_security_center_subscription_pricing.standard_plan[each.key]
+  id       = "${var.subscription_id}/providers/Microsoft.Security/pricings/${each.key}"
+}
+
+import {
+  for_each = { for config in local.defender_configs_free_plan : config.resource_type => config }
+  to       = azurerm_security_center_subscription_pricing.free_plan[each.key]
+  id       = "${var.subscription_id}/providers/Microsoft.Security/pricings/${each.key}"
+}
+
+import {
+  to = azapi_resource.security_contact
+  id = "${var.subscription_id}/providers/Microsoft.Security/securityContacts/default"
+}
+
 resource "azapi_resource" "security_contact" {
   type = "Microsoft.Security/securityContacts@2023-12-01-preview"
   # The only valid name for security contact is 'default'

--- a/modules/azure-defender/module.yaml
+++ b/modules/azure-defender/module.yaml
@@ -1,8 +1,8 @@
 name: azure-defender
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-defender
-version: 2.5.0
+version: 2.5.1
 changes:
-  - kind: added
-    description: "Support for Event Hub export"
+  - kind: fixed
+    description: "Import defender pricing tiers and the security contact instead of failing with \"already exists\" after they're lost from state (e.g. a prior `terraform destroy`, which only resets them to Free rather than deleting them)"
 


### PR DESCRIPTION
## Describe your changes

Defender pricing tiers (`azurerm_security_center_subscription_pricing`) and the security contact (`azapi_resource.security_contact`) are subscription-level singletons: Azure never actually deletes them, `terraform destroy` only resets pricing tiers to `Free` and leaves the security contact resource in place. Any subsequent `apply` after a state loss (destroy/apply cycles, state corruption, or a fresh `terraform init`) then tries to *create* these already-existing resources and fails with `... already exists - to be managed via Terraform this resource needs to be imported into the State`.

Added `import` blocks (native since Terraform 1.5, `for_each` support since 1.7 - this module requires `>= 1.5`) for all three resources. Since `import` is a no-op once the target address is already present in state, this is safe for tenants where the module already applied successfully too.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] `Contribution Guideline` read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`)