### PR TITLE
fix(azure-kubernetes-service): always emit node_provisioning_profile for ARM 5

### DIFF
--- a/modules/azure-kubernetes-service/main.tf
+++ b/modules/azure-kubernetes-service/main.tf
@@ -150,12 +150,9 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     }
   }
 
-  dynamic "node_provisioning_profile" {
-    for_each = var.node_autoscaling.mode == "node-auto-provisioning" ? [1] : []
-    content {
-      mode               = "Auto"
-      default_node_pools = var.node_autoscaling.node_auto_provisioning.default_node_pools
-    }
+  node_provisioning_profile {
+    mode               = var.node_autoscaling.mode == "node-auto-provisioning" ? "Auto" : "Manual"
+    default_node_pools = var.node_autoscaling.mode == "node-auto-provisioning" ? var.node_autoscaling.node_auto_provisioning.default_node_pools : null
   }
 
   default_node_pool {

--- a/modules/azure-kubernetes-service/module.yaml
+++ b/modules/azure-kubernetes-service/module.yaml
@@ -1,11 +1,9 @@
 name: azure-kubernetes-service
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-kubernetes-service
-version: 9.0.0
+version: 9.0.1
 compatibility:
   unique.ai: ~> 2025.20
 changes:
-  - kind: changed
-    description: "Upgrade to AzureRM provider 5."
-  - kind: changed
-    description: "Set the default Grafana major version to 13."
+  - kind: fixed
+    description: "Always emit node_provisioning_profile for AzureRM provider 5."


### PR DESCRIPTION
## Describe your changes

AzureRM provider 5 requires `node_provisioning_profile` on `azurerm_kubernetes_cluster`. The 9.0.0 module only emitted this block for `node-auto-provisioning` mode, causing plan failures for tenants using the default `cluster-autoscaler` mode.

Always emit the block: `Manual` for cluster-autoscaler/none, `Auto` for node-auto-provisioning.

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`)
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [ ] Compatibility updated where applicable  (`README.md`)
- [ ] Pre-Commit passed or has been run manually (`Makefile`)

Made with [Cursor](https://cursor.com)