### PR TITLE
feat(azure-postgresql): add private link support

### DIFF
--- a/modules/azure-postgresql/README.md
+++ b/modules/azure-postgresql/README.md
@@ -207,6 +207,27 @@ Zone-redundant HA provisions a synchronous standby replica in a separate Availab
 
 **Cost:** enabling HA doubles the compute cost. Storage is shared and does not double.
 
+## Private Link
+
+<small>Added in `4.1.0`.</small>
+
+Set `private_endpoint` to expose the server through a [private endpoint](https://learn.microsoft.com/en-us/azure/postgresql/network/concepts-networking-private-link) instead of (or in addition to) public access:
+
+```hcl
+module "postgresql" {
+  source = "..."
+
+  private_endpoint = {
+    subnet_id           = azurerm_subnet.example.id
+    private_dns_zone_id = azurerm_private_dns_zone.example.id # privatelink.postgres.database.azure.com
+  }
+
+  # ... other configuration
+}
+```
+
+Private Link only works for servers using public access networking — it cannot be combined with VNet integration (`delegated_subnet_id`). See the [private-endpoint example](./examples/private-endpoint) for a full setup.
+
 # Module
 
 <!-- BEGIN_TF_DOCS -->
@@ -243,6 +264,7 @@ No modules.
 | [azurerm_postgresql_flexible_server_configuration.parameters](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.destroy_prevented_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_postgresql_flexible_server_database.destroyable_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
+| [azurerm_private_endpoint.pe](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 
 ## Inputs
 
@@ -274,6 +296,7 @@ No modules.
 | <a name="input_port_secret_name"></a> [port\_secret\_name](#input\_port\_secret\_name) | Name of the secret containing the port | `string` | `null` | no |
 | <a name="input_postgresql_server_tags"></a> [postgresql\_server\_tags](#input\_postgresql\_server\_tags) | Additional tags that apply only to the PostgreSQL server. These will be merged with the general tags variable. | `map(string)` | `{}` | no |
 | <a name="input_private_dns_zone_id"></a> [private\_dns\_zone\_id](#input\_private\_dns\_zone\_id) | The ID of the private DNS zone. | `string` | `null` | no |
+| <a name="input_private_endpoint"></a> [private\_endpoint](#input\_private\_endpoint) | Configuration for a private endpoint (Private Link) to the PostgreSQL Flexible Server. When specified, creates a private endpoint in the given subnet and registers it in the given private DNS zone (privatelink.postgres.database.azure.com). Cannot be combined with VNet integration (delegated\_subnet\_id). | <pre>object({<br/>    subnet_id           = string<br/>    private_dns_zone_id = string<br/>    location            = optional(string)<br/>    tags                = optional(map(string), {})<br/>  })</pre> | `null` | no |
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Specifies whether this PostgreSQL Flexible Server is publicly accessible. Defaults to false | `string` | `false` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where the resources will be created. | `string` | n/a | yes |
 | <a name="input_secrets_tags"></a> [secrets\_tags](#input\_secrets\_tags) | Tags that apply to the secrets. Can be used to trigger a terraform refresh of the secrets. | `map(string)` | `{}` | no |

--- a/modules/azure-postgresql/examples/private-endpoint/main.tf
+++ b/modules/azure-postgresql/examples/private-endpoint/main.tf
@@ -1,0 +1,71 @@
+variable "subscription_id" {
+  type = string
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "switzerlandnorth"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-vn"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example-sn"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_private_dns_zone" "example" {
+  name                = "privatelink.postgres.database.azure.com"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "example" {
+  name                = "example-vnet-link"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = azurerm_virtual_network.example.id
+}
+
+resource "random_password" "postgres_username" {
+  length  = 16
+  special = false
+}
+
+resource "random_password" "postgres_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_string" "server_name" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+module "apfs" {
+  source              = "../.."
+  admin_password      = random_password.postgres_password.result
+  administrator_login = random_password.postgres_username.result
+  name                = "my-postgresql-server-${random_string.server_name.result}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  public_network_access_enabled = false
+
+  private_endpoint = {
+    subnet_id           = azurerm_subnet.example.id
+    private_dns_zone_id = azurerm_private_dns_zone.example.id
+  }
+
+  metric_alerts_external_action_group_ids = []
+
+  tags = {
+    environment = "example"
+  }
+}

--- a/modules/azure-postgresql/examples/private-endpoint/providers.tf
+++ b/modules/azure-postgresql/examples/private-endpoint/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 5"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/modules/azure-postgresql/main.tf
+++ b/modules/azure-postgresql/main.tf
@@ -75,6 +75,35 @@ resource "azurerm_postgresql_flexible_server" "apfs" {
   }
 }
 
+resource "azurerm_private_endpoint" "pe" {
+  count               = var.private_endpoint != null ? 1 : 0
+  name                = "${var.name}-pe"
+  location            = coalesce(var.private_endpoint.location, var.location)
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint.subnet_id
+  tags                = merge(var.tags, var.private_endpoint.tags)
+
+  private_service_connection {
+    name                           = "${var.name}-psc"
+    private_connection_resource_id = azurerm_postgresql_flexible_server.apfs.id
+    is_manual_connection           = false
+    subresource_names              = ["postgresqlServer"]
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [var.private_endpoint.private_dns_zone_id]
+  }
+
+  lifecycle {
+    precondition {
+      # https://learn.microsoft.com/en-us/azure/postgresql/network/concepts-networking-private-link
+      condition     = var.delegated_subnet_id == null
+      error_message = "Private Link is not supported for VNet-integrated servers. Unset delegated_subnet_id to use private_endpoint."
+    }
+  }
+}
+
 resource "azurerm_postgresql_flexible_server_configuration" "parameters" {
   for_each  = var.parameter_values
   server_id = azurerm_postgresql_flexible_server.apfs.id

--- a/modules/azure-postgresql/module.yaml
+++ b/modules/azure-postgresql/module.yaml
@@ -1,9 +1,9 @@
 name: azure-postgresql
 sources:
   - https://github.com/Unique-AG/terraform-modules/tree/main/modules/azure-postgresql
-version: 4.0.0
+version: 4.1.0
 compatibility:
   unique.ai: ~> 2025.16
 changes:
-  - kind: changed
-    description: "Upgrade to AzureRM provider 5."
+  - kind: added
+    description: "private_endpoint variable to expose the server via Private Link. Not supported for VNet-integrated servers (delegated_subnet_id)."

--- a/modules/azure-postgresql/variables.tf
+++ b/modules/azure-postgresql/variables.tf
@@ -89,6 +89,30 @@ variable "private_dns_zone_id" {
   default     = null
 }
 
+variable "private_endpoint" {
+  description = "Configuration for a private endpoint (Private Link) to the PostgreSQL Flexible Server. When specified, creates a private endpoint in the given subnet and registers it in the given private DNS zone (privatelink.postgres.database.azure.com). Cannot be combined with VNet integration (delegated_subnet_id)."
+  type = object({
+    subnet_id           = string
+    private_dns_zone_id = string
+    location            = optional(string)
+    tags                = optional(map(string), {})
+  })
+  default = null
+
+  validation {
+    condition = var.private_endpoint == null ? true : (
+      can(regex("^/subscriptions/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/resourceGroups/[^/]+/providers/Microsoft.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.private_endpoint.subnet_id))
+    )
+    error_message = "The subnet_id must be a valid Azure resource ID for a subnet"
+  }
+  validation {
+    condition = var.private_endpoint == null ? true : (
+      can(regex("^/subscriptions/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/resourceGroups/[^/]+/providers/Microsoft.Network/privateDnsZones/[^/]+$", var.private_endpoint.private_dns_zone_id))
+    )
+    error_message = "The private_dns_zone_id must be a valid Azure resource ID for a private DNS zone"
+  }
+}
+
 variable "identity_ids" {
   description = "List of managed identity IDs to assign to the storage account."
   type        = list(string)


### PR DESCRIPTION
## Describe your changes

Adds Private Link support to the `azure-postgresql` module per [UN-24273](https://unique-ch.atlassian.net/browse/UN-24273):

- New optional `private_endpoint` variable (`subnet_id`, `private_dns_zone_id`, optional `location`/`tags`), default `null` — no change for existing users.
- Creates an `azurerm_private_endpoint` with the `postgresqlServer` subresource and a `private_dns_zone_group` (`privatelink.postgres.database.azure.com`).
- Precondition rejects combining `private_endpoint` with VNet integration (`delegated_subnet_id`), which [Azure does not support](https://learn.microsoft.com/en-us/azure/postgresql/network/concepts-networking-private-link).
- New `examples/private-endpoint` example (passes `terraform init && validate`).
- README section + regenerated tf-docs.

Refs: UN-24273

## Checklist before requesting a review
- [x] Module version bumped (`module.yaml`) — 4.0.0 → 4.1.0
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/terraform-modules/blob/main/CONTRIBUTING.md) read and understood
- [x] Changelog updated and where applicable compatibility changed (`module.yaml`)
- [x] Compatibility updated where applicable (`README.md`)
- [x] Pre-Commit passed or has been run manually (`Makefile`) — tf-docs run with local binary (Docker daemon not running), fmt + example validation pass

[UN-24273]: https://unique-ch.atlassian.net/browse/UN-24273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ